### PR TITLE
chore(github): add CI workflow for build & test on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI (Build & Test)
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - "LICENSE"
+      - ".editorconfig"
+      - ".gitattributes"
+      - ".gitignore"
+      - "**/*.png"
+      - "**/*.jpg"
+      - "**/*.jpeg"
+      - "**/*.gif"
+      - "**/*.svg"
+  push:
+    branches: [ "main" ]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - "LICENSE"
+      - ".editorconfig"
+      - ".gitattributes"
+      - ".gitignore"
+      - "**/*.png"
+      - "**/*.jpg"
+      - "**/*.jpeg"
+      - "**/*.gif"
+      - "**/*.svg"
+  workflow_dispatch:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: ci-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Build
+        run: mvn -B -ntp -DskipTests package
+
+      - name: Test
+        run: mvn -B -ntp test


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to run Maven **build + tests** on pull requests and on the `main` branch (post-merge) to gate merges and keep the badge accurate.

## Changes

* Add `.github/workflows/ci.yml`:

  * Triggers: `pull_request -> main` (PR gate) and `push -> main` (badge refresh after merges)
  * JDK 21 via `actions/setup-java` with Maven cache
  * Separate steps: **Build** (`mvn -DskipTests package`) and **Test** (`mvn test`)

## How to Test

**Steps**

1. Open a PR against `main`.
2. Observe the “CI (Build & Test)” workflow runs automatically and turns green.
3. Merge the PR and observe the workflow runs again on `main` (post-merge).

**Expected**

* PR shows a required status check **CI (Build & Test)** and it passes.
* After merge, the **main** run completes successfully (badge stays current).

## Out of Scope

* Docker image build/publish (Continuous Delivery)

## Risks & Rollback

* Risk: Minor CI minutes increase.
* Rollback: revert PR; no data migration impact.

## CI Status

N/A (will run on this PR)

## Docs/Meta

* README unchanged
* OpenAPI docs unchanged
