### PR TITLE
fix(github): fix task and feature templates' tasks subsection

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -55,15 +55,19 @@ body:
     validations:
       required: true
 
-  - type: checkboxes
+  - type: textarea
     id: tasks
     attributes:
-      label: Tasks
+      label: Tasks (editable checklist)
       description: Keep it short; split if it grows too large.
-      options:
-        - label: Step 1 — …
-        - label: Step 2 — …
-        - label: Step 3 — …
+      placeholder: |
+        - [ ] Repo query with filters
+        - [ ] CSV/JSON streaming
+        - [ ] OpenAPI examples
+        - [ ] Integration tests
+      render: markdown
+    validations:
+      required: true
 
   - type: textarea
     id: verify

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -25,16 +25,18 @@ body:
         - ...
     validations:
       required: true
-
-  - type: checkboxes
+  - type: textarea
     id: tasks
     attributes:
       label: Tasks
-      description: Keep it short; split into another task if it grows.
-      options:
-        - label: Step 1 — …
-        - label: Step 2 — …
-        - label: Step 3 — …
+      description: Keep it short; split if it grows too large.
+      placeholder: |
+        - [ ] Step 1 — ...
+        - [ ] Step 2 — ...
+        - [ ] Step 3 — ...
+      render: markdown
+    validations:
+      required: true
 
   - type: textarea
     id: verify


### PR DESCRIPTION
## Summary
Fix the *Tasks* subsection of the Task & Feature issue templates, because prior was not editable.

## Changes
- Convert section from type `checkbox` to `textarea`.

## How to Test
**Setup**
- Branch: `*`

**Steps**
1) Go to Issues section in the repository.
2) Open a new issue with the Task or Feature template.
3) Check if the *Tasks* subsection is now editable.

**Expected**
- Tasks can now be edited and written in a textarea.

## Risks & Rollback
- Risk: Low (Github config only)
- Rollback: revert PR; no data migration impact.

## CI Status
- [x] CI (build) passes N/A
- [x] CI (tests) pass N/A

## Docs/Meta
- [x] README untouched
- [x] OpenAPI untouched

## Related
- Closes #5 
