### PR TITLE
feat(reservations): complete search filters with date range and guest free-text

### DIFF
--- a/src/main/java/com/rubenrzprz/reshub/reservation/ReservationController.java
+++ b/src/main/java/com/rubenrzprz/reshub/reservation/ReservationController.java
@@ -6,6 +6,7 @@ import com.rubenrzprz.reshub.security.RequestActorResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
 import java.util.UUID;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -56,7 +57,7 @@ public class ReservationController {
     return reservationQueryService.getById(id, actor);
   }
 
-  @Operation(summary = "List reservations with keyset pagination")
+  @Operation(summary = "List reservations with keyset pagination and filters")
   @ApiResponse(responseCode = "200", description = "Reservations listed and authorized")
   @ApiResponse(responseCode = "400", description = "Invalid pagination/filter input")
   @ApiResponse(responseCode = "401", description = "Missing/invalid actor context")
@@ -65,6 +66,9 @@ public class ReservationController {
     @RequestParam(name = "limit", defaultValue = "50") int limit,
     @RequestParam(name = "cursor", required = false) String cursor,
     @RequestParam(name = "status", required = false) String status,
+    @RequestParam(name = "arrivalFrom", required = false) LocalDate arrivalFrom,
+    @RequestParam(name = "arrivalTo", required = false) LocalDate arrivalTo,
+    @RequestParam(name = "guestQuery", required = false) String guestQuery,
     @RequestHeader(name = "X-User-Id", required = false) String userId,
     @RequestHeader(name = "X-Role", required = false) String role,
     @RequestHeader(name = "X-Hotel-Id", required = false) String hotelId,
@@ -73,8 +77,11 @@ public class ReservationController {
     if (limit < 1 || limit > 200) {
       throw new ApiProblemException(HttpStatus.BAD_REQUEST, "invalid_limit", "limit must be between 1 and 200");
     }
+    if (arrivalFrom != null && arrivalTo != null && arrivalFrom.isAfter(arrivalTo)) {
+      throw new ApiProblemException(HttpStatus.BAD_REQUEST, "invalid_date_range", "arrivalFrom must be on or before arrivalTo");
+    }
     RequestActor actor = actorResolver.resolve(userId, role, hotelId, agencyId);
-    return reservationQueryService.list(actor, limit, cursor, status);
+    return reservationQueryService.list(actor, limit, cursor, status, arrivalFrom, arrivalTo, guestQuery);
   }
 
   @Operation(summary = "Create reservation")

--- a/src/main/java/com/rubenrzprz/reshub/reservation/ReservationQueryService.java
+++ b/src/main/java/com/rubenrzprz/reshub/reservation/ReservationQueryService.java
@@ -67,7 +67,15 @@ public class ReservationQueryService {
     return reservation;
   }
 
-  public ReservationListResponse list(RequestActor actor, int limit, String cursor, String status) {
+  public ReservationListResponse list(
+    RequestActor actor,
+    int limit,
+    String cursor,
+    String status,
+    LocalDate arrivalFrom,
+    LocalDate arrivalTo,
+    String guestQuery
+  ) {
     CursorKey cursorKey = parseCursor(cursor);
 
     List<Object> args = new ArrayList<>();
@@ -92,6 +100,28 @@ public class ReservationQueryService {
     if (status != null && !status.isBlank()) {
       sql.append("and status = ? ");
       args.add(status);
+    }
+
+    if (arrivalFrom != null) {
+      sql.append("and arrival_date >= ? ");
+      args.add(Date.valueOf(arrivalFrom));
+    }
+
+    if (arrivalTo != null) {
+      sql.append("and arrival_date <= ? ");
+      args.add(Date.valueOf(arrivalTo));
+    }
+
+    if (guestQuery != null && !guestQuery.isBlank()) {
+      String guestPattern = "%" + guestQuery.trim().toLowerCase() + "%";
+      sql.append("and (");
+      sql.append("lower(guest_name) like ? ");
+      sql.append("or lower(coalesce(guest_email, '')) like ? ");
+      sql.append("or lower(coalesce(guest_phone, '')) like ? ");
+      sql.append(") ");
+      args.add(guestPattern);
+      args.add(guestPattern);
+      args.add(guestPattern);
     }
 
     if (cursorKey != null) {

--- a/src/test/java/com/rubenrzprz/reshub/reservation/ReservationApiIT.java
+++ b/src/test/java/com/rubenrzprz/reshub/reservation/ReservationApiIT.java
@@ -777,8 +777,214 @@ class ReservationApiIT {
       .jsonPath("$.items[0].hotelId").isEqualTo(seed.hotelId.toString());
   }
 
+  @Test
+  void arrivalDateRangeFilterAppliesWithinManagerScope() {
+    insertReservation(seed, seed.hotelId, seed.agencyId, seed.managerUserId, "NEW", LocalDate.of(2026, 2, 18));
+    insertReservation(seed, seed.hotelId, seed.agencyId, seed.managerUserId, "NEW", LocalDate.of(2026, 2, 23));
+    insertReservation(seed, seed.otherHotelId, seed.otherAgencyId, seed.otherManagerUserId, "NEW", LocalDate.of(2026, 2, 22));
+
+    client.get().uri(uriBuilder -> uriBuilder.path("/reservations")
+      .queryParam("arrivalFrom", "2026-02-20")
+      .queryParam("arrivalTo", "2026-02-22")
+      .queryParam("limit", 50)
+      .build())
+      .header("X-User-Id", seed.managerUserId.toString())
+      .header("X-Role", "MANAGER")
+      .header("X-Hotel-Id", seed.hotelId.toString())
+      .exchange()
+      .expectStatus().isOk()
+      .expectBody()
+      .jsonPath("$.items.length()").isEqualTo(1)
+      .jsonPath("$.items[0].arrivalDate").isEqualTo("2026-02-20")
+      .jsonPath("$.items[0].hotelId").isEqualTo(seed.hotelId.toString());
+  }
+
+  @Test
+  void guestQueryFiltersByNameWithinManagerScope() {
+    insertReservationWithGuest(
+      seed,
+      seed.hotelId,
+      seed.agencyId,
+      seed.managerUserId,
+      "NEW",
+      LocalDate.of(2026, 2, 21),
+      "Alice Smith",
+      "alice@example.com",
+      "+34111111111"
+    );
+    insertReservationWithGuest(
+      seed,
+      seed.hotelId,
+      seed.agencyId,
+      seed.managerUserId,
+      "NEW",
+      LocalDate.of(2026, 2, 22),
+      "Bob Johnson",
+      "bob@example.com",
+      "+34222222222"
+    );
+    insertReservationWithGuest(
+      seed,
+      seed.otherHotelId,
+      seed.otherAgencyId,
+      seed.otherManagerUserId,
+      "NEW",
+      LocalDate.of(2026, 2, 22),
+      "Alice Outside",
+      "outside@example.com",
+      "+34333333333"
+    );
+
+    client.get().uri(uriBuilder -> uriBuilder.path("/reservations")
+      .queryParam("guestQuery", "smith")
+      .queryParam("limit", 50)
+      .build())
+      .header("X-User-Id", seed.managerUserId.toString())
+      .header("X-Role", "MANAGER")
+      .header("X-Hotel-Id", seed.hotelId.toString())
+      .exchange()
+      .expectStatus().isOk()
+      .expectBody()
+      .jsonPath("$.items.length()").isEqualTo(1)
+      .jsonPath("$.items[0].guestName").isEqualTo("Alice Smith")
+      .jsonPath("$.items[0].hotelId").isEqualTo(seed.hotelId.toString());
+  }
+
+  @Test
+  void guestQueryCanMatchEmailWithinAgencyScope() {
+    insertReservationWithGuest(
+      seed,
+      seed.hotelId,
+      seed.agencyId,
+      seed.agencyUserId,
+      "NEW",
+      LocalDate.of(2026, 2, 21),
+      "Agency Match",
+      "match@agency.com",
+      "+34111111111"
+    );
+    insertReservationWithGuest(
+      seed,
+      seed.hotelId,
+      seed.otherAgencyId,
+      seed.otherAgencyUserId,
+      "NEW",
+      LocalDate.of(2026, 2, 22),
+      "Other Agency Match",
+      "match@agency.com",
+      "+34222222222"
+    );
+
+    client.get().uri(uriBuilder -> uriBuilder.path("/reservations")
+      .queryParam("guestQuery", "MATCH@AGENCY.COM")
+      .queryParam("limit", 50)
+      .build())
+      .header("X-User-Id", seed.agencyUserId.toString())
+      .header("X-Role", "AGENCY")
+      .header("X-Agency-Id", seed.agencyId.toString())
+      .exchange()
+      .expectStatus().isOk()
+      .expectBody()
+      .jsonPath("$.items.length()").isEqualTo(1)
+      .jsonPath("$.items[0].agencyId").isEqualTo(seed.agencyId.toString())
+      .jsonPath("$.items[0].guestName").isEqualTo("Agency Match");
+  }
+
+  @Test
+  void combinedStatusDateAndGuestFiltersReturnIntersection() {
+    insertReservationWithGuest(
+      seed,
+      seed.hotelId,
+      seed.agencyId,
+      seed.managerUserId,
+      "CONFIRMED",
+      LocalDate.of(2026, 2, 21),
+      "Alice Combined",
+      "alice-combined@example.com",
+      "+34111111111"
+    );
+    insertReservationWithGuest(
+      seed,
+      seed.hotelId,
+      seed.agencyId,
+      seed.managerUserId,
+      "NEW",
+      LocalDate.of(2026, 2, 21),
+      "Alice Wrong Status",
+      "alice-wrong@example.com",
+      "+34222222222"
+    );
+    insertReservationWithGuest(
+      seed,
+      seed.hotelId,
+      seed.agencyId,
+      seed.managerUserId,
+      "CONFIRMED",
+      LocalDate.of(2026, 2, 25),
+      "Alice Wrong Date",
+      "alice-date@example.com",
+      "+34333333333"
+    );
+
+    client.get().uri(uriBuilder -> uriBuilder.path("/reservations")
+      .queryParam("status", "CONFIRMED")
+      .queryParam("arrivalFrom", "2026-02-20")
+      .queryParam("arrivalTo", "2026-02-22")
+      .queryParam("guestQuery", "alice")
+      .queryParam("limit", 50)
+      .build())
+      .header("X-User-Id", seed.managerUserId.toString())
+      .header("X-Role", "MANAGER")
+      .header("X-Hotel-Id", seed.hotelId.toString())
+      .exchange()
+      .expectStatus().isOk()
+      .expectBody()
+      .jsonPath("$.items.length()").isEqualTo(1)
+      .jsonPath("$.items[0].status").isEqualTo("CONFIRMED")
+      .jsonPath("$.items[0].arrivalDate").isEqualTo("2026-02-21")
+      .jsonPath("$.items[0].guestName").isEqualTo("Alice Combined");
+  }
+
+  @Test
+  void invalidDateRangeIsBadRequest() {
+    client.get().uri(uriBuilder -> uriBuilder.path("/reservations")
+      .queryParam("arrivalFrom", "2026-02-23")
+      .queryParam("arrivalTo", "2026-02-22")
+      .queryParam("limit", 50)
+      .build())
+      .header("X-User-Id", seed.managerUserId.toString())
+      .header("X-Role", "MANAGER")
+      .header("X-Hotel-Id", seed.hotelId.toString())
+      .exchange()
+      .expectStatus().isBadRequest()
+      .expectBody()
+      .jsonPath("$.code").isEqualTo("invalid_date_range");
+  }
+
   private UUID insertReservation(Seed s) {
     return insertReservation(s, s.receptionistUserId);
+  }
+
+  private UUID insertReservationWithGuest(
+    Seed s,
+    UUID hotelId,
+    UUID agencyId,
+    UUID createdByUserId,
+    String status,
+    LocalDate arrivalDate,
+    String guestName,
+    String guestEmail,
+    String guestPhone
+  ) {
+    UUID reservationIdWithGuest = insertReservation(s, hotelId, agencyId, createdByUserId, status, arrivalDate);
+    jdbc.update(
+      "update reservation set guest_name = ?, guest_email = ?, guest_phone = ? where id = ?",
+      guestName,
+      guestEmail,
+      guestPhone,
+      reservationIdWithGuest
+    );
+    return reservationIdWithGuest;
   }
 
   private Map<String, Object> createPayload(UUID hotelId, UUID agencyId, String externalRef) {


### PR DESCRIPTION
## Summary
- Change: Added `arrivalFrom`, `arrivalTo`, and `guestQuery` filters to `GET /reservations`, including validation and integration coverage.
- Reason: Completes issue #26 so reservation search matches documented MVP behavior.

## Changes
- [updated] `GET /reservations` query contract with `arrivalFrom`, `arrivalTo`, `guestQuery`.
- [added] Date-range validation in controller: `arrivalFrom > arrivalTo` returns `400` with `invalid_date_range`.
- [updated] Reservation list SQL filtering:
  - `arrival_date >= arrivalFrom`
  - `arrival_date <= arrivalTo`
  - case-insensitive guest match over `guest_name`, `guest_email`, `guest_phone`
- [added] Integration tests for:
  - date range filtering in scope
  - guest free-text filtering (name and email)
  - combined `status + date range + guestQuery` intersection
  - invalid date range bad request

## How to Test
**Setup**
- Branch: `feat/reservations-search-filters`
- Commands: `mvn -q test`

**Steps**
1) Run `mvn -q test`.
2) Call:
   - `GET /reservations?arrivalFrom=2026-02-20&arrivalTo=2026-02-22`
   - `GET /reservations?guestQuery=smith`
   - `GET /reservations?status=CONFIRMED&arrivalFrom=2026-02-20&arrivalTo=2026-02-22&guestQuery=alice`
3) Call invalid range:
   - `GET /reservations?arrivalFrom=2026-02-23&arrivalTo=2026-02-22`

**Expected**
- Filtered responses include only scoped matching rows.
- Combined filters behave as intersection.
- Invalid date range returns `400` with code `invalid_date_range`.
- Existing role scoping behavior remains unchanged.

## Out of Scope
- Export endpoints/formats.
- Fuzzy ranking/trigram indexing.
- New data model or migration changes.

## Risks & Rollback
- Risk: Query complexity/regression in list behavior; mitigated by integration tests covering filter composition and role scope.
- Rollback: `git revert 6b4c9b2` or revert PR; no data migration impact.

## CI Status
- [ ] CI (build) passes
- [ ] CI (tests) pass
- [ ] Image build/publish (if enabled) passes

## Docs/Meta
- [ ] README unchanged
- [x] OpenAPI updated

## Related
Closes #26