### PR TITLE
chore(ci): run full Maven lifecycle with verify in GitHub Actions (refs #36)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,5 @@ jobs:
           java-version: '21'
           cache: maven
 
-      - name: Build
-        run: mvn -B -ntp -DskipTests package
-
-      - name: Test
-        run: mvn -B -ntp test
+      - name: Verify
+        run: mvn -B -ntp verify


### PR DESCRIPTION
## Summary
Run CI with a single `mvn -B -ntp verify` command so build, unit tests, and integration tests execute in one lifecycle-aligned step.
- Change: Replaced split Maven steps (`package -DskipTests` + `test`) with one `verify` step in `.github/workflows/ci.yml`.
- Reason: `verify` already covers build and test phases, and ensures failsafe-bound integration suites run in PR CI.

## Changes
- updated GitHub Actions workflow to use one Maven step: `mvn -B -ntp verify`
- removed redundant build/test split in CI job
- kept workflow triggers, caching, and runner setup unchanged

## How to Test
**Setup**
- Branch: `chore/ci-use-maven-verify`
- Commands:
  - `mvn -B -ntp verify`
  - push branch and inspect GitHub Actions run

**Steps**
1) Open the `CI (Build & Test)` workflow run for this branch/PR.
2) Confirm the Maven command executed is `mvn -B -ntp verify`.
3) Review logs to verify lifecycle execution includes compile/package/unit tests/integration tests.
4) Confirm workflow finishes green.

**Expected**
- Workflow uses a single `verify` step.
- Build and both unit/integration test execution happen in the same run.
- CI passes with no behavior change outside command/lifecycle alignment.

## Out of Scope
- application code changes
- test logic refactors
- Maven plugin reconfiguration beyond CI command selection

## Risks & Rollback
- Risk: CI duration/profile may shift because lifecycle is now executed in one command.
- Rollback: `git revert 5cc167c` or revert PR; no data migration impact.

## CI Status
- [x] CI (build) passes
- [x] CI (tests) pass
- [ ] Image build/publish (if enabled) passes

## Docs/Meta
- [ ] README unchanged
- [ ] OpenAPI unchanged

## Related
Closes #36 