### PR TITLE
feat(reservations): add feature-flagged agency-hotel authorization model (V5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ See the full domain & data model in **[📐 Architecture](docs/Architecture.md)*
 - 🔎 Search by date range, status, and free-text guest; pagination & sorting
 - 📤 CSV/JSON export of filtered results
 - 🧭 Idempotent `externalRef` per (hotel, agency)
+- 🧾 Feature-flagged agency-hotel authorization (`features.enforce-agency-hotel-auth`)
 - 🧱 Standardized `ProblemDetail` error codes (401/403/404/409/400 paths)
 - ✅ Integration tests with **Testcontainers (Postgres)**
 
@@ -110,11 +111,23 @@ docker compose up --build
 ### 🧪 Tests
 
 ```bash
-mvn -q test
+mvn -q verify
 ```
 
 * Integration tests that hit PostgreSQL use **Testcontainers**.
 * The test suite verifies that the baseline database schema is applied.
+
+### 🚩 Feature Flags
+
+Agency-hotel authorization enforcement is controlled by:
+
+```yaml
+features:
+  enforce-agency-hotel-auth: false
+```
+
+When enabled, AGENCY create/read/list operations require an `ACTIVE` `agency_hotel_auth` row
+for the target hotel whose validity window includes the reservation `arrival_date`.
 
 ### 🔐 Authentication (JWT)
 
@@ -137,6 +150,7 @@ curl http://localhost:8080/reservations \
 
 * Reservation endpoints use bearer authentication.
 * Legacy actor headers (`X-User-Id`, `X-Role`, `X-Hotel-Id`, `X-Agency-Id`) are disabled.
+* If agency-hotel auth is enabled and denied, API returns `403` with code `agency_not_authorized_for_hotel`.
 
 ### 📤 Export Endpoints
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,6 +1,6 @@
 # 🏗️ ResHub — Architecture (Domain & Data Model)
 
-**Version:** 0.3 (MVP)  
+**Version:** 0.4 (MVP)  
 **Status:** Draft — authoritative design for MVP; kept in sync with migrations
 
 ---
@@ -262,7 +262,7 @@
 
 **Semantics**
 
-* If feature flag `enforceAgencyHotelAuth=true`: at create (AGENCY), require ACTIVE row whose validity window covers the arrival date. At read/list, scope to authorized hotels.
+* If feature flag `enforceAgencyHotelAuth=true`: at create/read/list (AGENCY), require ACTIVE row whose validity window covers the reservation arrival date.
 
 ---
 
@@ -395,6 +395,7 @@
 
 ## 13) 📝 Change Log
 
+* v0.4 — Implemented V5 agency authorization schema and feature-flagged AGENCY create/read/list enforcement with `agency_not_authorized_for_hotel`.
 * v0.3 — Added reservations/comments lifecycle constraints (V4), RBAC service/API enforcement, and standardized `ProblemDetail` error codes.
 * v0.2 — Added room_type_channel_map hotel integrity constraints (V3).
 * v0.1 — Initial MVP model (this document).

--- a/src/main/java/com/rubenrzprz/reshub/ReshubApplication.java
+++ b/src/main/java/com/rubenrzprz/reshub/ReshubApplication.java
@@ -1,5 +1,6 @@
 package com.rubenrzprz.reshub;
 
+import com.rubenrzprz.reshub.reservation.ReservationFeatureFlagsProperties;
 import com.rubenrzprz.reshub.security.JwtProperties;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
@@ -7,7 +8,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
-@EnableConfigurationProperties(JwtProperties.class)
+@EnableConfigurationProperties({JwtProperties.class, ReservationFeatureFlagsProperties.class})
 @OpenAPIDefinition(
   info = @Info(
     title = "ResHub API",

--- a/src/main/java/com/rubenrzprz/reshub/reservation/AgencyHotelAuthorizationService.java
+++ b/src/main/java/com/rubenrzprz/reshub/reservation/AgencyHotelAuthorizationService.java
@@ -1,0 +1,46 @@
+package com.rubenrzprz.reshub.reservation;
+
+import com.rubenrzprz.reshub.security.RequestActor;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AgencyHotelAuthorizationService {
+
+  private final JdbcTemplate jdbc;
+  private final ReservationFeatureFlagsProperties flags;
+
+  public AgencyHotelAuthorizationService(JdbcTemplate jdbc, ReservationFeatureFlagsProperties flags) {
+    this.jdbc = jdbc;
+    this.flags = flags;
+  }
+
+  public boolean isAgencyAuthorizedForHotelOnDate(RequestActor actor, UUID hotelId, LocalDate date) {
+    if (!isAgencyAuthEnforced(actor)) {
+      return true;
+    }
+
+    Integer count = jdbc.queryForObject(
+      "select count(*) " +
+        "from agency_hotel_auth " +
+        "where agency_id = ? " +
+        "  and hotel_id = ? " +
+        "  and status = 'ACTIVE' " +
+        "  and (valid_from is null or valid_from <= ?) " +
+        "  and (valid_to is null or valid_to >= ?)",
+      Integer.class,
+      actor.agencyId(),
+      hotelId,
+      date,
+      date
+    );
+
+    return count != null && count > 0;
+  }
+
+  public boolean isAgencyAuthEnforced(RequestActor actor) {
+    return flags.enforceAgencyHotelAuth() && actor.role() == RequestActor.Role.AGENCY;
+  }
+}

--- a/src/main/java/com/rubenrzprz/reshub/reservation/ReservationCommandService.java
+++ b/src/main/java/com/rubenrzprz/reshub/reservation/ReservationCommandService.java
@@ -3,6 +3,7 @@ package com.rubenrzprz.reshub.reservation;
 import com.rubenrzprz.reshub.api.ApiProblemException;
 import com.rubenrzprz.reshub.security.RequestActor;
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -23,10 +24,16 @@ public class ReservationCommandService {
 
   private final JdbcTemplate jdbc;
   private final ReservationQueryService reservationQueryService;
+  private final AgencyHotelAuthorizationService agencyHotelAuthorizationService;
 
-  public ReservationCommandService(JdbcTemplate jdbc, ReservationQueryService reservationQueryService) {
+  public ReservationCommandService(
+    JdbcTemplate jdbc,
+    ReservationQueryService reservationQueryService,
+    AgencyHotelAuthorizationService agencyHotelAuthorizationService
+  ) {
     this.jdbc = jdbc;
     this.reservationQueryService = reservationQueryService;
+    this.agencyHotelAuthorizationService = agencyHotelAuthorizationService;
   }
 
   public ReservationView updateNotes(UUID reservationId, String notes, RequestActor actor) {
@@ -234,8 +241,22 @@ public class ReservationCommandService {
       case ADMIN -> {
       }
       case MANAGER, RECEPTIONIST -> ReservationRbacGuards.requireHotelScope(actor, request.hotelId(), onDeny);
-      case AGENCY -> ReservationRbacGuards.requireAgencyScope(actor, request.agencyId(), onDeny);
+      case AGENCY -> {
+        ReservationRbacGuards.requireAgencyScope(actor, request.agencyId(), onDeny);
+        enforceAgencyHotelAuthorization(actor, request.hotelId(), request.arrivalDate(), onDeny);
+      }
       default -> onDeny.accept(ReservationRbacLog.REASON_UNSUPPORTED_ROLE);
+    }
+  }
+
+  private void enforceAgencyHotelAuthorization(
+    RequestActor actor,
+    UUID hotelId,
+    LocalDate arrivalDate,
+    Consumer<String> onDeny
+  ) {
+    if (!agencyHotelAuthorizationService.isAgencyAuthorizedForHotelOnDate(actor, hotelId, arrivalDate)) {
+      onDeny.accept(ReservationRbacLog.REASON_AGENCY_HOTEL_AUTH_MISSING_OR_INVALID);
     }
   }
 
@@ -297,6 +318,13 @@ public class ReservationCommandService {
         reason
       )
     );
+    if (ReservationRbacLog.REASON_AGENCY_HOTEL_AUTH_MISSING_OR_INVALID.equals(reason)) {
+      throw new ApiProblemException(
+        HttpStatus.FORBIDDEN,
+        "agency_not_authorized_for_hotel",
+        "agency is not authorized for hotel"
+      );
+    }
     throw new ApiProblemException(HttpStatus.FORBIDDEN, "forbidden_scope", "forbidden reservation scope");
   }
 

--- a/src/main/java/com/rubenrzprz/reshub/reservation/ReservationController.java
+++ b/src/main/java/com/rubenrzprz/reshub/reservation/ReservationController.java
@@ -49,7 +49,7 @@ public class ReservationController {
   @Operation(summary = "Get reservation by id")
   @ApiResponse(responseCode = "200", description = "Reservation found and authorized")
   @ApiResponse(responseCode = "401", description = "Missing/invalid actor context")
-  @ApiResponse(responseCode = "403", description = "Forbidden by role scope")
+  @ApiResponse(responseCode = "403", description = "Forbidden by role scope or agency-hotel authorization policy")
   @ApiResponse(responseCode = "404", description = "Reservation not found")
   @GetMapping("/reservations/{id}")
   public ReservationView getById(
@@ -67,6 +67,7 @@ public class ReservationController {
   @ApiResponse(responseCode = "200", description = "Reservations listed and authorized")
   @ApiResponse(responseCode = "400", description = "Invalid pagination/filter input")
   @ApiResponse(responseCode = "401", description = "Missing/invalid actor context")
+  @ApiResponse(responseCode = "403", description = "Forbidden by role scope or agency-hotel authorization policy")
   @GetMapping("/reservations")
   public ReservationListResponse list(
     @RequestParam(name = "limit", defaultValue = "50") int limit,
@@ -138,7 +139,7 @@ public class ReservationController {
   @ApiResponse(responseCode = "201", description = "Reservation created and authorized")
   @ApiResponse(responseCode = "400", description = "Invalid reservation payload")
   @ApiResponse(responseCode = "401", description = "Missing/invalid actor context")
-  @ApiResponse(responseCode = "403", description = "Forbidden by role scope")
+  @ApiResponse(responseCode = "403", description = "Forbidden by role scope or agency-hotel authorization policy")
   @ApiResponse(responseCode = "409", description = "Duplicate external reference")
   @PostMapping("/reservations")
   @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/com/rubenrzprz/reshub/reservation/ReservationFeatureFlagsProperties.java
+++ b/src/main/java/com/rubenrzprz/reshub/reservation/ReservationFeatureFlagsProperties.java
@@ -1,0 +1,9 @@
+package com.rubenrzprz.reshub.reservation;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "features")
+public record ReservationFeatureFlagsProperties(
+  boolean enforceAgencyHotelAuth
+) {
+}

--- a/src/main/java/com/rubenrzprz/reshub/reservation/ReservationQueryService.java
+++ b/src/main/java/com/rubenrzprz/reshub/reservation/ReservationQueryService.java
@@ -22,9 +22,14 @@ public class ReservationQueryService {
   private static final Logger log = LoggerFactory.getLogger(ReservationQueryService.class);
 
   private final JdbcTemplate jdbc;
+  private final AgencyHotelAuthorizationService agencyHotelAuthorizationService;
 
-  public ReservationQueryService(JdbcTemplate jdbc) {
+  public ReservationQueryService(
+    JdbcTemplate jdbc,
+    AgencyHotelAuthorizationService agencyHotelAuthorizationService
+  ) {
     this.jdbc = jdbc;
+    this.agencyHotelAuthorizationService = agencyHotelAuthorizationService;
   }
 
   public ReservationView getById(UUID reservationId, RequestActor actor) {
@@ -184,6 +189,7 @@ public class ReservationQueryService {
       case AGENCY -> {
         sql.append("agency_id = ? ");
         args.add(actor.agencyId());
+        appendAgencyHotelAuthorizationFilter(sql, args, actor);
       }
       default -> throw new ApiProblemException(HttpStatus.FORBIDDEN, "forbidden_scope", "forbidden reservation scope");
     }
@@ -216,19 +222,62 @@ public class ReservationQueryService {
     }
   }
 
+  private void appendAgencyHotelAuthorizationFilter(
+    StringBuilder sql,
+    List<Object> args,
+    RequestActor actor
+  ) {
+    if (!agencyHotelAuthorizationService.isAgencyAuthEnforced(actor)) {
+      return;
+    }
+    sql.append("and exists (");
+    sql.append("select 1 from agency_hotel_auth aha ");
+    sql.append("where aha.agency_id = ? ");
+    sql.append("and aha.hotel_id = reservation.hotel_id ");
+    sql.append("and aha.status = 'ACTIVE' ");
+    sql.append("and (aha.valid_from is null or aha.valid_from <= reservation.arrival_date) ");
+    sql.append("and (aha.valid_to is null or aha.valid_to >= reservation.arrival_date)");
+    sql.append(") ");
+    args.add(actor.agencyId());
+  }
+
   private void enforceReadAccess(RequestActor actor, ReservationView reservation) {
     Consumer<String> onDeny = reason -> deny(actor, reservation.id(), reason);
     switch (actor.role()) {
       case ADMIN -> {
       }
       case MANAGER, RECEPTIONIST -> ReservationRbacGuards.requireHotelScope(actor, reservation.hotelId(), onDeny);
-      case AGENCY -> ReservationRbacGuards.requireAgencyScope(actor, reservation.agencyId(), onDeny);
+      case AGENCY -> {
+        ReservationRbacGuards.requireAgencyScope(actor, reservation.agencyId(), onDeny);
+        enforceAgencyHotelAuthorization(actor, reservation, onDeny);
+      }
       default -> onDeny.accept(ReservationRbacLog.REASON_UNSUPPORTED_ROLE);
+    }
+  }
+
+  private void enforceAgencyHotelAuthorization(
+    RequestActor actor,
+    ReservationView reservation,
+    Consumer<String> onDeny
+  ) {
+    if (!agencyHotelAuthorizationService.isAgencyAuthorizedForHotelOnDate(
+      actor,
+      reservation.hotelId(),
+      reservation.arrivalDate()
+    )) {
+      onDeny.accept(ReservationRbacLog.REASON_AGENCY_HOTEL_AUTH_MISSING_OR_INVALID);
     }
   }
 
   private void deny(RequestActor actor, UUID reservationId, String reason) {
     log.warn("{}", ReservationRbacLog.readFields(actor, reservationId, "DENY", reason));
+    if (ReservationRbacLog.REASON_AGENCY_HOTEL_AUTH_MISSING_OR_INVALID.equals(reason)) {
+      throw new ApiProblemException(
+        HttpStatus.FORBIDDEN,
+        "agency_not_authorized_for_hotel",
+        "agency is not authorized for hotel"
+      );
+    }
     throw new ApiProblemException(HttpStatus.FORBIDDEN, "forbidden_scope", "forbidden reservation scope");
   }
 

--- a/src/main/java/com/rubenrzprz/reshub/reservation/ReservationRbacLog.java
+++ b/src/main/java/com/rubenrzprz/reshub/reservation/ReservationRbacLog.java
@@ -31,6 +31,7 @@ final class ReservationRbacLog {
   static final String REASON_AGENCY_SCOPE_MISMATCH = "agency_scope_mismatch";
   static final String REASON_OWNER_MISMATCH = "owner_mismatch";
   static final String REASON_COMMENTS_INTERNAL_ONLY = "comments_internal_only";
+  static final String REASON_AGENCY_HOTEL_AUTH_MISSING_OR_INVALID = "agency_hotel_auth_missing_or_invalid";
   static final String REASON_INVALID_TRANSITION = "invalid_transition";
   static final String REASON_UNSUPPORTED_ROLE = "unsupported_role";
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,5 @@ security:
     secret: "${JWT_SECRET:}"
     issuer: "reshub"
     expiration-minutes: 60
+features:
+  enforce-agency-hotel-auth: false

--- a/src/main/resources/db/migration/V5__agency-hotel-authorization.sql
+++ b/src/main/resources/db/migration/V5__agency-hotel-authorization.sql
@@ -1,0 +1,27 @@
+-- Agency-hotel coarse authorization (feature-flagged enforcement)
+create table if not exists agency_hotel_auth
+(
+  id uuid primary key,
+  agency_id uuid not null references agency(id) on delete restrict,
+  hotel_id uuid not null references hotel(id) on delete restrict,
+  status varchar(12) not null,
+  valid_from date null,
+  valid_to date null,
+  terms_json jsonb null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint agency_hotel_auth_status_check check (status in ('ACTIVE', 'SUSPENDED', 'ENDED')),
+  constraint agency_hotel_auth_validity_check check (valid_from is null or valid_to is null or valid_from <= valid_to),
+  constraint agency_hotel_auth_agency_hotel_unique unique (agency_id, hotel_id)
+  );
+
+create index if not exists idx_agency_hotel_auth_agency on agency_hotel_auth(agency_id);
+create index if not exists idx_agency_hotel_auth_hotel on agency_hotel_auth(hotel_id);
+
+-- Optional granular room-type allowlist per authorization
+create table if not exists agency_hotel_room_type_allow
+(
+  auth_id uuid not null references agency_hotel_auth(id) on delete cascade,
+  room_type_id uuid not null references room_type(id) on delete restrict,
+  primary key (auth_id, room_type_id)
+  );

--- a/src/test/java/com/rubenrzprz/reshub/flyway/FlywayReservationsIT.java
+++ b/src/test/java/com/rubenrzprz/reshub/flyway/FlywayReservationsIT.java
@@ -148,6 +148,19 @@ class FlywayReservationsIT extends FlywayIntegrationTestBase {
     Assertions.assertEquals(1, count);
   }
 
+  @Test
+  void v5AgencyAuthorizationTablesConstraintsAndIndexesExist() {
+    Assertions.assertEquals(1, tableExists("agency_hotel_auth"));
+    Assertions.assertEquals(1, tableExists("agency_hotel_room_type_allow"));
+
+    Assertions.assertEquals(1, constraintExists("agency_hotel_auth_status_check"));
+    Assertions.assertEquals(1, constraintExists("agency_hotel_auth_validity_check"));
+    Assertions.assertEquals(1, constraintExists("agency_hotel_auth_agency_hotel_unique"));
+
+    Assertions.assertEquals(1, indexExists("agency_hotel_auth", "idx_agency_hotel_auth_agency"));
+    Assertions.assertEquals(1, indexExists("agency_hotel_auth", "idx_agency_hotel_auth_hotel"));
+  }
+
   private void insertReservation(
     Seed seed,
     UUID reservationId,

--- a/src/test/java/com/rubenrzprz/reshub/reservation/ReservationAgencyHotelAuthApiIT.java
+++ b/src/test/java/com/rubenrzprz/reshub/reservation/ReservationAgencyHotelAuthApiIT.java
@@ -1,0 +1,218 @@
+package com.rubenrzprz.reshub.reservation;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDate;
+
+@TestPropertySource(properties = "features.enforce-agency-hotel-auth=true")
+public class ReservationAgencyHotelAuthApiIT extends ReservationApiIntegrationTestBase {
+
+  @Test
+  void agencyCreateAllowedActiveAuthCoversArrivalDate() {
+    dataFactory.insertAgencyHotelAuth(
+      seed.agencyId(),
+      seed.hotelId(),
+      "ACTIVE",
+      LocalDate.of(2026, 1, 1),
+      LocalDate.of(2026, 12, 31)
+    );
+
+    client.post().uri("/reservations")
+      .header("Authorization", "Bearer " + agencyToken)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(createPayload(seed.hotelId(), seed.agencyId(), "ext-agency-auth-ok"))
+      .exchange()
+      .expectStatus().isCreated();
+  }
+
+  @Test
+  void agencyCreateDeniedWhenNoAuthRow() {
+    client.post().uri("/reservations")
+      .header("Authorization", "Bearer " + agencyToken)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(createPayload(seed.hotelId(), seed.agencyId(), "ext-agency-auth-ok"))
+      .exchange()
+      .expectStatus().isForbidden()
+      .expectBody()
+      .jsonPath("$.code").isEqualTo("agency_not_authorized_for_hotel");
+  }
+
+  @Test
+  void agencyReadDeniedWhenAuthDoesNotCoverArrivalDate() {
+    // baseline reservation arrival_date is 2026-02-20 in test factory
+    dataFactory.insertAgencyHotelAuth(
+      seed.agencyId(),
+      seed.hotelId(),
+      "ACTIVE",
+      LocalDate.of(2026, 2, 21),
+      LocalDate.of(2026, 12, 31)
+    );
+
+    client.get().uri("/reservations/{id}", reservationId)
+      .header("Authorization", "Bearer " + agencyToken)
+      .exchange()
+      .expectStatus().isForbidden()
+      .expectBody()
+      .jsonPath("$.code").isEqualTo("agency_not_authorized_for_hotel");
+  }
+
+  @Test
+  void agencyReadAllowedWhenAuthCoversArrivalDate() {
+    dataFactory.insertAgencyHotelAuth(
+      seed.agencyId(),
+      seed.hotelId(),
+      "ACTIVE",
+      LocalDate.of(2026, 1, 1),
+      LocalDate.of(2026, 12, 31)
+    );
+
+    client.get().uri("/reservations/{id}", reservationId)
+      .header("Authorization", "Bearer " + agencyToken)
+      .exchange()
+      .expectStatus().isOk();
+  }
+
+  @Test
+  void agencyListReturnsOnlyAuthorizedHotelsByArrivalDate() {
+    //unauthorized hotel reservation
+    dataFactory.insertReservation(
+      seed,
+      seed.otherHotelId(),
+      seed.agencyId(),
+      seed.agencyUserId(),
+      "NEW",
+      LocalDate.of(2026, 2, 20)
+    );
+
+    dataFactory.insertAgencyHotelAuth(
+      seed.agencyId(),
+      seed.hotelId(),
+      "ACTIVE",
+      LocalDate.of(2026, 1, 1),
+      LocalDate.of(2026, 12, 31)
+    );
+
+    client.get().uri(uriBuilder -> uriBuilder.path("/reservations").queryParam("limit", 50).build())
+      .header("Authorization", "Bearer " + agencyToken)
+      .exchange()
+      .expectStatus().isOk()
+      .expectBody()
+      .jsonPath("$.items.length()").isEqualTo(1)
+      .jsonPath("$.items[0].id").isEqualTo(reservationId.toString());
+  }
+
+  @Test
+  void nonAgencyRoleUnchangedWhenFlagEnabled() {
+    client.get().uri("/reservations/{id}", reservationId)
+      .header("Authorization", "Bearer " + managerToken)
+      .exchange()
+      .expectStatus().isOk();
+
+    client.post().uri("/reservations")
+      .header("Authorization", "Bearer " + managerToken)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(createPayload(seed.hotelId(), seed.agencyId(), "ext-manager-unchanged"))
+      .exchange()
+      .expectStatus().isCreated();
+  }
+
+  @Test
+  void agencyCreateDeniedWhenAuthStatusIsSuspended() {
+    dataFactory.insertAgencyHotelAuth(
+      seed.agencyId(),
+      seed.hotelId(),
+      "SUSPENDED",
+      LocalDate.of(2026, 1, 1),
+      LocalDate.of(2026, 12, 31)
+    );
+
+    client.post().uri("/reservations")
+      .header("Authorization", "Bearer " + agencyToken)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(createPayload(seed.hotelId(), seed.agencyId(), "ext-agency-suspended"))
+      .exchange()
+      .expectStatus().isForbidden()
+      .expectBody()
+      .jsonPath("$.code").isEqualTo("agency_not_authorized_for_hotel");
+  }
+
+  @Test
+  void agencyReadAllowedOnValidityBoundaries() {
+    // reservationId has arrival_date 2026-02-20 from test factory
+    dataFactory.insertAgencyHotelAuth(
+      seed.agencyId(),
+      seed.hotelId(),
+      "ACTIVE",
+      LocalDate.of(2026, 2, 20),
+      LocalDate.of(2026, 2, 20)
+    );
+
+    client.get().uri("/reservations/{id}", reservationId)
+      .header("Authorization", "Bearer " + agencyToken)
+      .exchange()
+      .expectStatus().isOk();
+  }
+
+  @Test
+  void agencyReadAllowedWhenValidFromIsNullAndValidToCoversArrivalDate() {
+    dataFactory.insertAgencyHotelAuth(
+      seed.agencyId(),
+      seed.hotelId(),
+      "ACTIVE",
+      null,
+      LocalDate.of(2026, 2, 20)
+    );
+
+    client.get().uri("/reservations/{id}", reservationId)
+      .header("Authorization", "Bearer " + agencyToken)
+      .exchange()
+      .expectStatus().isOk();
+  }
+
+  @Test
+  void agencyReadAllowedWhenValidToIsNullAndValidFromCoversArrivalDate() {
+    dataFactory.insertAgencyHotelAuth(
+      seed.agencyId(),
+      seed.hotelId(),
+      "ACTIVE",
+      LocalDate.of(2026, 2, 20),
+      null
+    );
+
+    client.get().uri("/reservations/{id}", reservationId)
+      .header("Authorization", "Bearer " + agencyToken)
+      .exchange()
+      .expectStatus().isOk();
+  }
+
+  @Test
+  void agencyListExcludesSameHotelReservationsOutsideAuthDateRange() {
+    // same hotel out of range
+    dataFactory.insertReservation(
+      seed,
+      seed.hotelId(),
+      seed.agencyId(),
+      seed.agencyUserId(),
+      "NEW",
+      LocalDate.of(2026, 2, 25)
+    );
+
+    dataFactory.insertAgencyHotelAuth(
+      seed.agencyId(),
+      seed.hotelId(),
+      "ACTIVE",
+      LocalDate.of(2026, 2, 19),
+      LocalDate.of(2026, 2, 21)
+    );
+
+    client.get().uri(uriBuilder -> uriBuilder.path("/reservations").queryParam("limit", 50).build())
+      .header("Authorization", "Bearer " + agencyToken)
+      .exchange()
+      .expectStatus().isOk()
+      .expectBody()
+      .jsonPath("$.items.length()").isEqualTo(1)
+      .jsonPath("$.items[0].id").isEqualTo(reservationId.toString());
+  }
+}

--- a/src/test/java/com/rubenrzprz/reshub/reservation/support/ReservationTestDataFactory.java
+++ b/src/test/java/com/rubenrzprz/reshub/reservation/support/ReservationTestDataFactory.java
@@ -16,7 +16,16 @@ public class ReservationTestDataFactory {
   }
 
   public void truncateAll() {
-    jdbc.execute("truncate table reservation_comment, reservation, room_type_channel_map, room_type, app_user, agency, hotel restart identity cascade");
+    jdbc.execute("truncate table " +
+      "agency_hotel_room_type_allow, " +
+      "agency_hotel_auth, " +
+      "reservation_comment, " +
+      "reservation, " +
+      "room_type_channel_map, " +
+      "room_type, app_user, " +
+      "agency, " +
+      "hotel " +
+      "restart identity cascade");
   }
 
   public Seed seedBaseline(String validPassword) {
@@ -184,6 +193,27 @@ public class ReservationTestDataFactory {
       "Test Guest",
       2,
       0
+    );
+    return id;
+  }
+
+  public UUID insertAgencyHotelAuth(
+    UUID agencyId,
+    UUID hotelId,
+    String status,
+    LocalDate validFrom,
+    LocalDate validTo
+  ) {
+    UUID id = UUID.randomUUID();
+    jdbc.update(
+      "insert into agency_hotel_auth (id, agency_id, hotel_id, status, valid_from, valid_to) " +
+        "values (?, ?, ?, ?, ?, ?)",
+      id,
+      agencyId,
+      hotelId,
+      status,
+      validFrom == null ? null : java.sql.Date.valueOf(validFrom),
+      validTo == null ? null : java.sql.Date.valueOf(validTo)
     );
     return id;
   }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,3 +11,5 @@ security:
     secret: "test-secret-key-with-at-least-32-characters"
     issuer: "reshub-test"
     expiration-minutes: 60
+features:
+  enforce-agency-hotel-auth: false


### PR DESCRIPTION
## Summary
Implement V5 agency-hotel authorization and enforce it for AGENCY create/read/list behind a feature flag, preserving current behavior by default.
- Change: Added V5 schema (`agency_hotel_auth`, `agency_hotel_room_type_allow`), feature flag wiring, enforcement logic, standardized denial code, tests, and docs.
- Reason: Enable contract-driven cross-tenant agency access control with safe rollout (`features.enforce-agency-hotel-auth=false` by default).

## Changes
- added Flyway migration `V5__agency-hotel-authorization.sql`
- added reservation feature flag properties and default config:
  - `features.enforce-agency-hotel-auth: false` (`application.yml`, `application-test.yml`)
- added `AgencyHotelAuthorizationService` and integrated checks in reservation services
- enforced AGENCY auth for:
  - create (`POST /reservations`)
  - read (`GET /reservations/{id}`)
  - list (`GET /reservations`) via SQL filter
- added standardized 403 code on auth denial: `agency_not_authorized_for_hotel`
- updated reservation OpenAPI response descriptions for 403 policy context
- added migration + integration coverage for flag off/on and auth outcomes
- updated README/Architecture docs (including `mvn -q verify` test workflow)

## How to Test
**Setup**
- Branch: `feat/agency-hotel-auth-model`
- Commands:
  - `mvn -q verify`

**Steps**
1) Run `mvn -q verify` and confirm all tests pass.
2) Start app with flag OFF and verify existing agency flows remain unchanged.
3) Start app with `features.enforce-agency-hotel-auth=true`.
4) Insert ACTIVE valid auth for one hotel and no valid auth for another.
5) Execute AGENCY create/read/list against both hotels and compare outcomes.

**Expected**
- Flag OFF: no behavior change.
- Flag ON:
  - authorized hotel/date -> success
  - unauthorized hotel/date -> `403` with code `agency_not_authorized_for_hotel`
- non-agency roles remain unchanged.

## Out of Scope
- room-type granular enforcement (`agency_hotel_room_type_allow`) beyond schema scaffolding
- admin UI/automation for contract lifecycle management

## Risks & Rollback
- Risk: stricter AGENCY behavior when flag is enabled could block requests if auth rows are missing/misaligned.
- Rollback: revert PR or disable feature flag; data migration impact: **yes** (V5 tables added).

## CI Status
- [ ] CI (build) passes
- [ ] CI (tests) pass
- [ ] Image build/publish (if enabled) passes

## Docs/Meta
- [x] README updated
- [x] OpenAPI updated (`src/main/java/com/rubenrzprz/reshub/reservation/ReservationController.java`)

## Related
Closes #29