### PR TITLE
chore: enforce Java 21 builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ High-level overview of the domain & data model. For the full spec, see **[docs/A
 ResHub is designed to be run as a **full local stack** using Docker Compose.
 This guarantees the same behavior locally, in CI, and in future environments.
 
+### Requirements
+
+* **Java 21** for Maven builds and tests. The build enforces Java 21 so local runs match CI.
+* **Docker** for Docker Compose and Testcontainers-backed integration tests.
+
 ### 🐳 Run with Docker Compose (API + DB)
 
 One command builds and runs the complete development stack:
@@ -113,6 +118,8 @@ docker compose up --build
 ```bash
 mvn -q verify
 ```
+
+Run this command with a Java 21 JDK. Newer JDKs are rejected by Maven Enforcer so failures are explicit instead of surfacing as test framework incompatibilities.
 
 * Integration tests that hit PostgreSQL use **Testcontainers**.
 * The test suite verifies that the baseline database schema is applied.

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,27 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <id>enforce-java-21</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[21,22)</version>
+                  <message>ResHub must be built with Java 21. Use a JDK 21 runtime for Maven to match CI and the project target.</message>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.4</version>
         <configuration>

--- a/src/test/java/com/rubenrzprz/reshub/security/JwtAuthFilterTest.java
+++ b/src/test/java/com/rubenrzprz/reshub/security/JwtAuthFilterTest.java
@@ -5,13 +5,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
-import static org.mockito.Mockito.mock;
-
 class JwtAuthFilterTest {
 
+  private static final String TEST_SECRET = "test-secret-key-with-at-least-32-characters";
+
+  private final HandlerExceptionResolver resolver = (request, response, handler, ex) -> null;
   private final JwtAuthFilter filter = new JwtAuthFilter(
-    mock(JwtService.class),
-    mock(HandlerExceptionResolver.class)
+    new JwtService(new JwtProperties(TEST_SECRET, "reshub-test", 60)),
+    resolver
   );
 
   @Test


### PR DESCRIPTION
## Summary
Make the Java runtime requirement explicit and fail fast when Maven is run with an unsupported JDK.
- Change: Added Maven Enforcer for Java 21, documented local requirements, and removed Mockito from a filter path-matching unit test.
- Reason: Local `mvn verify` was being run on Java 25, causing Mockito/Byte Buddy failures instead of a clear project-runtime mismatch.

## Changes
- [added] Maven Enforcer rule requiring Java 21 (`[21,22)`).
- [updated] README requirements and test instructions to call out Java 21 and Docker.
- [updated] `JwtAuthFilterTest` to construct real lightweight collaborators instead of Mockito mocks for `shouldNotFilter` coverage.

## How to Test
**Setup**
- Branch: `chore/enforce-java-21`
- Commands:
  - `mvn -q validate`
  - `mvn -q '-Denforcer.skip=true' test`
  - `mvn -q verify` on a Java 21 JDK

**Steps**
1) Run `mvn -q validate` with a non-Java-21 runtime, such as Java 25.
2) Confirm Maven fails during validation with the Java 21 enforcer message.
3) Run `mvn -q verify` with Java 21 selected.
4) Confirm unit and integration tests pass under the supported runtime.

**Expected**
- Unsupported JDKs fail early with a clear Java 21 requirement.
- Java 21 remains aligned with CI and project target bytecode.
- `JwtAuthFilterTest` no longer depends on Mockito inline mocking for simple path-matching coverage.

## Out of Scope
- Installing or configuring a local Java 21 toolchain on developer machines.
- Changing CI runtime, which already uses Java 21.
- Broader security or JWT implementation refactors.

## Risks & Rollback
- Risk: Contributors with only newer JDKs installed must switch Maven to Java 21 before building.
- Rollback: `git revert 9c767da` or revert PR; no data migration impact.

## CI Status
- [ ] CI (build) passes
- [ ] CI (tests) pass
- [ ] Image build/publish (if enabled) passes

## Docs/Meta
- [x] README updated
- [ ] OpenAPI unchanged

## Related
Closes #44