### PR TITLE
chore: clarify JdbcTemplate persistence architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ See the full domain & data model in **[📐 Architecture](docs/Architecture.md)*
 | 🧱 **Framework**  | Spring Boot 3                             |
 | 🧷 **Build**      | Maven                                     |
 | 🗄️ **Database**  | PostgreSQL 16                             |
+| 🧾 **Persistence**| JdbcTemplate + explicit SQL              |
 | 🔁 **Migrations** | Flyway                                    |
 | 🧪 **Testing**    | JUnit 5, Spring Boot Test, Testcontainers |
 | 📚 **API Docs**   | OpenAPI (springdoc)                       |
@@ -58,6 +59,7 @@ See the full domain & data model in **[📐 Architecture](docs/Architecture.md)*
 High-level overview of the domain & data model. For the full spec, see **[docs/Architecture.md](docs/Architecture.md)**.
 
 - **Tenancy:** single DB; entities scoped by `hotel_id` where applicable.
+- **Persistence:** explicit SQL through Spring `JdbcTemplate`; Flyway owns schema evolution.
 - **Core entities:** `hotel`, `agency`, `app_user`, `room_type`, `room_type_channel_map`, `reservation`, `reservation_comment`.
 - **Reservations:** lifecycle `NEW → CONFIRMED → CANCELLED | NOSHOW`; never delete (use status + `cancelled_at`).
 - **Lifecycle guardrails:** terminal reservations (`CANCELLED`, `NOSHOW`) are immutable.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -49,6 +49,7 @@
 ## 2) 🏷️ Tenancy & Conventions
 
 - **Tenancy:** single DB; reference & operational rows scoped by `hotel_id` where applicable.
+- **Persistence:** application code uses Spring `JdbcTemplate` with explicit SQL. Flyway migrations define the schema; there are no JPA entities or Hibernate-managed DDL in the MVP.
 - **PKs:** UUID (application-assigned) — avoids DB extensions.
 - **Time:** `TIMESTAMPTZ` in UTC; JVM `-Duser.timezone=UTC`.  
 - **Naming:** snake_case table/column names; singular table names.

--- a/docs/decisions/0003-use-jdbc-template-over-jpa.md
+++ b/docs/decisions/0003-use-jdbc-template-over-jpa.md
@@ -1,0 +1,27 @@
+# 0003 - Use JdbcTemplate Over JPA
+
+## Context
+
+ResHub is a compact backend portfolio project with a PostgreSQL-first data model, Flyway-managed schema, role-scoped queries, keyset pagination, and database constraints for reservation integrity.
+
+The codebase already uses explicit SQL through Spring `JdbcTemplate`. Keeping Spring Data JPA in the build without entities or repositories made the persistence story look accidental.
+
+## Decision
+
+Use Spring `JdbcTemplate` and explicit SQL for the MVP persistence layer. Remove the unused Spring Data JPA dependency and Hibernate-specific configuration.
+
+## Rationale
+
+This keeps the database contract visible and aligned with Flyway migrations. It also makes query behavior for RBAC scoping, filters, exports, and keyset pagination straightforward to inspect and test.
+
+For this project, showing SQL literacy and schema ownership is more valuable than adding an ORM layer that would mostly wrap simple persistence operations.
+
+## Trade-offs
+
+`JdbcTemplate` requires manual row mapping and more explicit query maintenance. It also means the project is less conventional than a typical Spring Data JPA CRUD service.
+
+The trade-off is intentional: ResHub prioritizes transparent SQL, PostgreSQL constraints, and predictable query behavior over ORM abstraction.
+
+## Future Evolution
+
+If the model grows enough that entity state management, relationship traversal, or repository conventions become valuable, selected areas can move to Spring Data JPA. Complex reporting, exports, and authorization-scoped queries may still remain explicit SQL.

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <!-- Persistence & migrations -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <artifactId>spring-boot-starter-jdbc</artifactId>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,14 +3,6 @@ spring:
     url: jdbc:postgresql://db:5432/${POSTGRES_DB:reshub}
     username: ${POSTGRES_USER:reshub}
     password: ${POSTGRES_PASSWORD:reshub}
-  jpa:
-    hibernate:
-      ddl-auto: validate
-    properties:
-      hibernate:
-        jdbc:
-          time_zone: UTC
-    open-in-view: false
   flyway:
     enabled: true
     locations: classpath:db/migration

--- a/src/test/java/com/rubenrzprz/reshub/support/PostgresIntegrationTestBase.java
+++ b/src/test/java/com/rubenrzprz/reshub/support/PostgresIntegrationTestBase.java
@@ -22,7 +22,6 @@ public abstract class PostgresIntegrationTestBase {
     r.add("spring.datasource.url", postgres::getJdbcUrl);
     r.add("spring.datasource.username", postgres::getUsername);
     r.add("spring.datasource.password", postgres::getPassword);
-    r.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
     r.add("spring.flyway.enabled", () -> "true");
   }
 }


### PR DESCRIPTION
## Summary
Make the persistence architecture explicit by aligning dependencies, configuration, and docs with the existing JdbcTemplate implementation.
- Change: Replaced unused Spring Data JPA dependency with Spring JDBC, removed Hibernate-only config, and documented the JdbcTemplate decision.
- Reason: The project already uses explicit SQL and Flyway; leaving JPA in the build made the architecture look accidental and harder to defend.

## Changes
- [updated] `pom.xml` to use `spring-boot-starter-jdbc` instead of `spring-boot-starter-data-jpa`.
- [removed] Hibernate/JPA validation settings from `application-dev.yml` and test dynamic properties.
- [added] ADR `docs/decisions/0003-use-jdbc-template-over-jpa.md`.
- [updated] README tech stack and architecture summary to state JdbcTemplate + explicit SQL.
- [updated] `docs/Architecture.md` tenancy/conventions section with the persistence decision.

## How to Test
**Setup**
- Branch: `chore/clarify-jdbc-persistence`
- Commands:
  - `mvn -q verify` on a Java 21 JDK
  - `mvn -q '-Denforcer.skip=true' '-DskipTests' package` on this local Java 25 environment

**Steps**
1) Confirm the dependency tree no longer includes `spring-boot-starter-data-jpa`.
2) Start the application or run tests with Java 21.
3) Confirm Flyway still applies migrations and `JdbcTemplate`-based services still start.
4) Review README, Architecture, and ADR for the documented persistence story.

**Expected**
- Application keeps DataSource, JdbcTemplate, PostgreSQL, and Flyway support.
- No Hibernate/JPA DDL validation settings remain.
- Persistence choice is documented as intentional, including trade-offs.

## Out of Scope
- Migrating services to Spring Data JPA.
- Refactoring SQL out of services into separate repository classes.
- Changing reservation query behavior or schema migrations.

## Risks & Rollback
- Risk: Removing JPA may surface any accidental hidden dependency on Hibernate auto-configuration; package verification showed none locally.
- Rollback: `git revert 45db9bc` or revert PR; no data migration impact.

## CI Status
- [ ] CI (build) passes
- [ ] CI (tests) pass
- [ ] Image build/publish (if enabled) passes

## Docs/Meta
- [x] README updated
- [ ] OpenAPI unchanged

## Related
Closes #46