### PR TITLE
docs: decide persistence strategy

### DIFF
--- a/docs/decisions/0001-migrate-core-persistence-to-jpa.md
+++ b/docs/decisions/0001-migrate-core-persistence-to-jpa.md
@@ -1,0 +1,60 @@
+# 0001 - Migrate Core Persistence to Spring Data JPA
+
+## Context
+
+ResHub is a Spring Boot portfolio backend. The current implementation uses Flyway for schema ownership and `JdbcTemplate` for all production persistence:
+
+- `AuthService` queries `app_user` for token issuance.
+- `AgencyHotelAuthorizationService` checks agency-hotel authorization rows.
+- `ReservationCommandService` inserts and mutates reservations/comments.
+- `ReservationQueryService` handles role-scoped reads, filters, keyset pagination, and export queries.
+
+The project already depends on Spring Data JPA and configures Hibernate validation, but it has no entities or repositories. That makes the persistence architecture look inconsistent in an interview.
+
+## Decision
+
+Migrate core persistence to Spring Data JPA in a follow-up implementation PR, while keeping Flyway as the only schema migration mechanism.
+
+Core aggregate persistence should move first:
+
+- `hotel`
+- `agency`
+- `app_user`
+- `reservation`
+- `reservation_comment`
+- `agency_hotel_auth`
+
+Query-heavy paths may keep explicit SQL where it is clearer or more efficient, especially:
+
+- role-scoped reservation listing
+- keyset pagination ordered by `(arrival_date, id)`
+- CSV/JSON export filters
+- authorization existence checks
+
+## Rationale
+
+For Java/Spring Boot interviews, JPA entities and repositories are a familiar signal. They show that the project can use the mainstream Spring persistence model rather than only raw SQL.
+
+JPA also gives a cleaner place to express aggregate structure and repository boundaries. That helps separate business logic from SQL strings currently embedded in services.
+
+Flyway remains responsible for DDL because the project already has a strong PostgreSQL schema, constraints, and migration tests. Hibernate should validate mapping compatibility, not generate or mutate schema.
+
+## Trade-offs
+
+JPA adds ORM complexity, especially around lazy loading, transaction boundaries, and entity state. Not every query should be forced into derived repository methods.
+
+Keeping selected explicit SQL is acceptable when it protects clarity or performance. The goal is not to remove SQL completely; the goal is to make the default persistence style conventional and intentional.
+
+## Implementation Plan
+
+1. Add JPA entities matching the existing Flyway schema.
+2. Add repositories for core lookup and command paths.
+3. Move `AuthService` user lookup to an `AppUserRepository`.
+4. Move simple reservation/comment create and status update paths to repositories.
+5. Keep complex list/export queries explicit initially, either through `JdbcTemplate` or custom repository implementations.
+6. Keep `spring.jpa.hibernate.ddl-auto=validate` in dev/test to catch entity-schema drift.
+7. Add focused tests for repository mappings and preserve existing API integration tests.
+
+## Future Evolution
+
+If the JPA migration creates more complexity than value in a specific query path, keep that path explicit and document why. The final architecture can be hybrid: JPA for aggregate persistence, explicit SQL for operational reporting and role-scoped search.


### PR DESCRIPTION
## Summary
Document the persistence strategy decision before changing dependencies or refactoring services.
- Change: Added ADR 0001 choosing a Spring Data JPA migration for core persistence, while keeping Flyway as schema owner and allowing explicit SQL for query-heavy paths.
- Reason: The project currently has JPA on the classpath but uses only JdbcTemplate; this needs an intentional interview-defendable direction before implementation work.

## Changes
- [added] `docs/decisions/0001-migrate-core-persistence-to-jpa.md`
- [documented] current JdbcTemplate usage across auth, authorization, reservation command, and reservation query paths
- [documented] decision to migrate core aggregate persistence to Spring Data JPA in follow-up issue #48
- [documented] hybrid boundary where explicit SQL remains acceptable for keyset pagination, exports, and role-scoped operational queries

## How to Test
**Setup**
- Branch: `chore/assess-persistence-strategy`
- Commands: documentation-only change; no runtime command required

**Steps**
1) Read `docs/decisions/0001-migrate-core-persistence-to-jpa.md`.
2) Confirm it compares the current JdbcTemplate implementation with the proposed JPA direction.
3) Confirm it keeps Flyway as schema authority.
4) Confirm implementation work is tracked separately in issue #48.

**Expected**
- Persistence direction is explicit before any dependency/config refactor.
- JPA is selected as the preferred interview-friendly path.
- Complex SQL-heavy paths are not forced into JPA prematurely.

## Out of Scope
- Adding entities or repositories.
- Removing JdbcTemplate usage.
- Changing dependencies or application behavior.
- Updating OpenAPI.

## Risks & Rollback
- Risk: The ADR sets direction but does not complete the implementation; issue #48 tracks that migration.
- Rollback: `git revert 92ea1d2` or revert PR; no data migration impact.

## CI Status
- [ ] CI (build) passes
- [ ] CI (tests) pass
- [ ] Image build/publish (if enabled) passes

## Docs/Meta
- [ ] README unchanged
- [ ] OpenAPI unchanged

## Related
Closes #46
Refs #48