### PR TITLE
refactor: migrate core persistence to JPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ See the full domain & data model in **[📐 Architecture](docs/Architecture.md)*
 | 🧱 **Framework**  | Spring Boot 3                             |
 | 🧷 **Build**      | Maven                                     |
 | 🗄️ **Database**  | PostgreSQL 16                             |
+| 🧾 **Persistence**| Spring Data JPA + targeted JdbcTemplate  |
 | 🔁 **Migrations** | Flyway                                    |
 | 🧪 **Testing**    | JUnit 5, Spring Boot Test, Testcontainers |
 | 📚 **API Docs**   | OpenAPI (springdoc)                       |
@@ -58,6 +59,7 @@ See the full domain & data model in **[📐 Architecture](docs/Architecture.md)*
 High-level overview of the domain & data model. For the full spec, see **[docs/Architecture.md](docs/Architecture.md)**.
 
 - **Tenancy:** single DB; entities scoped by `hotel_id` where applicable.
+- **Persistence:** Spring Data JPA for core aggregate commands/lookups; explicit `JdbcTemplate` SQL for role-scoped list/export queries.
 - **Core entities:** `hotel`, `agency`, `app_user`, `room_type`, `room_type_channel_map`, `reservation`, `reservation_comment`.
 - **Reservations:** lifecycle `NEW → CONFIRMED → CANCELLED | NOSHOW`; never delete (use status + `cancelled_at`).
 - **Lifecycle guardrails:** terminal reservations (`CANCELLED`, `NOSHOW`) are immutable.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -49,6 +49,7 @@
 ## 2) 🏷️ Tenancy & Conventions
 
 - **Tenancy:** single DB; reference & operational rows scoped by `hotel_id` where applicable.
+- **Persistence:** Flyway owns schema migrations; Spring Data JPA handles core aggregate commands/lookups; explicit SQL remains for role-scoped list/export/keyset queries.
 - **PKs:** UUID (application-assigned) — avoids DB extensions.
 - **Time:** `TIMESTAMPTZ` in UTC; JVM `-Duser.timezone=UTC`.  
 - **Naming:** snake_case table/column names; singular table names.

--- a/docs/decisions/0001-migrate-core-persistence-to-jpa.md
+++ b/docs/decisions/0001-migrate-core-persistence-to-jpa.md
@@ -2,20 +2,20 @@
 
 ## Context
 
-ResHub is a Spring Boot portfolio backend. The current implementation uses Flyway for schema ownership and `JdbcTemplate` for all production persistence:
+ResHub is a Spring Boot portfolio backend. Before this decision, the implementation used Flyway for schema ownership and `JdbcTemplate` for all production persistence:
 
 - `AuthService` queries `app_user` for token issuance.
 - `AgencyHotelAuthorizationService` checks agency-hotel authorization rows.
 - `ReservationCommandService` inserts and mutates reservations/comments.
 - `ReservationQueryService` handles role-scoped reads, filters, keyset pagination, and export queries.
 
-The project already depends on Spring Data JPA and configures Hibernate validation, but it has no entities or repositories. That makes the persistence architecture look inconsistent in an interview.
+The project already depended on Spring Data JPA and configured Hibernate validation, but it had no entities or repositories. That made the persistence architecture look inconsistent in an interview.
 
 ## Decision
 
-Migrate core persistence to Spring Data JPA in a follow-up implementation PR, while keeping Flyway as the only schema migration mechanism.
+Migrate core persistence to Spring Data JPA while keeping Flyway as the only schema migration mechanism.
 
-Core aggregate persistence should move first:
+Core aggregate persistence moves first:
 
 - `hotel`
 - `agency`
@@ -24,7 +24,7 @@ Core aggregate persistence should move first:
 - `reservation_comment`
 - `agency_hotel_auth`
 
-Query-heavy paths may keep explicit SQL where it is clearer or more efficient, especially:
+Query-heavy paths keep explicit SQL where it is clearer or more efficient, especially:
 
 - role-scoped reservation listing
 - keyset pagination ordered by `(arrival_date, id)`
@@ -45,15 +45,15 @@ JPA adds ORM complexity, especially around lazy loading, transaction boundaries,
 
 Keeping selected explicit SQL is acceptable when it protects clarity or performance. The goal is not to remove SQL completely; the goal is to make the default persistence style conventional and intentional.
 
-## Implementation Plan
+## Implemented Boundary
 
-1. Add JPA entities matching the existing Flyway schema.
-2. Add repositories for core lookup and command paths.
-3. Move `AuthService` user lookup to an `AppUserRepository`.
-4. Move simple reservation/comment create and status update paths to repositories.
-5. Keep complex list/export queries explicit initially, either through `JdbcTemplate` or custom repository implementations.
-6. Keep `spring.jpa.hibernate.ddl-auto=validate` in dev/test to catch entity-schema drift.
-7. Add focused tests for repository mappings and preserve existing API integration tests.
+- JPA entities match the existing Flyway schema for core aggregate tables.
+- Repositories support core lookup and command paths.
+- `AuthService` uses `AppUserRepository`.
+- `AgencyHotelAuthorizationService` uses `AgencyHotelAuthRepository`.
+- `ReservationCommandService` uses repositories for reservation/comment create and mutation paths.
+- `ReservationQueryService` keeps explicit `JdbcTemplate` SQL for role-scoped list/read/export behavior.
+- `spring.jpa.hibernate.ddl-auto=validate` stays enabled in dev/test to catch entity-schema drift.
 
 ## Future Evolution
 

--- a/src/main/java/com/rubenrzprz/reshub/auth/AuthService.java
+++ b/src/main/java/com/rubenrzprz/reshub/auth/AuthService.java
@@ -1,25 +1,25 @@
 package com.rubenrzprz.reshub.auth;
 
 import com.rubenrzprz.reshub.api.ApiProblemException;
+import com.rubenrzprz.reshub.persistence.AppUserEntity;
+import com.rubenrzprz.reshub.persistence.AppUserRepository;
 import com.rubenrzprz.reshub.security.JwtService;
 import org.springframework.http.HttpStatus;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.UUID;
 
 @Service
 public class AuthService {
 
-  private final JdbcTemplate jdbc;
+  private final AppUserRepository appUserRepository;
   private final JwtService jwtService;
   private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
-  public AuthService(JdbcTemplate jdbc, JwtService jwtService) {
-    this.jdbc = jdbc;
+  public AuthService(AppUserRepository appUserRepository, JwtService jwtService) {
+    this.appUserRepository = appUserRepository;
     this.jwtService = jwtService;
   }
 
@@ -46,18 +46,7 @@ public class AuthService {
   private AuthUser findByEmail(String email) {
     String normalized = email.toLowerCase(Locale.ROOT).trim();
 
-    List<AuthUser> rows = jdbc.query(
-      "select id, email, password_hash, role, hotel_id, agency_id from app_user where lower(email) = ?",
-      (rs, rowNum) -> new AuthUser(
-        UUID.fromString(rs.getString("id")),
-        rs.getString("email"),
-        rs.getString("password_hash"),
-        rs.getString("role"),
-        rs.getString("hotel_id") == null ? null : UUID.fromString(rs.getString("hotel_id")),
-        rs.getString("agency_id") == null ? null : UUID.fromString(rs.getString("agency_id"))
-      ),
-      normalized
-    );
+    List<AppUserEntity> rows = appUserRepository.findByEmailIgnoreCase(normalized);
 
     if (rows.isEmpty()) {
       throw invalidCredentials();
@@ -66,7 +55,15 @@ public class AuthService {
       throw invalidCredentials();
     }
 
-    return rows.getFirst();
+    AppUserEntity user = rows.getFirst();
+    return new AuthUser(
+      user.getId(),
+      user.getEmail(),
+      user.getPasswordHash(),
+      user.getRole(),
+      user.getHotelId(),
+      user.getAgencyId()
+    );
   }
 
   private ApiProblemException invalidCredentials() {

--- a/src/main/java/com/rubenrzprz/reshub/persistence/AgencyEntity.java
+++ b/src/main/java/com/rubenrzprz/reshub/persistence/AgencyEntity.java
@@ -1,0 +1,38 @@
+package com.rubenrzprz.reshub.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "agency")
+public class AgencyEntity {
+
+  @Id
+  private UUID id;
+
+  @Column(nullable = false, length = 24)
+  private String code;
+
+  @Column(nullable = false, length = 120)
+  private String name;
+
+  @Column(nullable = false)
+  private boolean active;
+
+  @Column(name = "created_at", nullable = false)
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
+
+  protected AgencyEntity() {
+  }
+
+  public UUID getId() {
+    return id;
+  }
+}

--- a/src/main/java/com/rubenrzprz/reshub/persistence/AgencyHotelAuthEntity.java
+++ b/src/main/java/com/rubenrzprz/reshub/persistence/AgencyHotelAuthEntity.java
@@ -1,0 +1,45 @@
+package com.rubenrzprz.reshub.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "agency_hotel_auth")
+public class AgencyHotelAuthEntity {
+
+  @Id
+  private UUID id;
+
+  @Column(name = "agency_id", nullable = false)
+  private UUID agencyId;
+
+  @Column(name = "hotel_id", nullable = false)
+  private UUID hotelId;
+
+  @Column(nullable = false, length = 12)
+  private String status;
+
+  @Column(name = "valid_from")
+  private LocalDate validFrom;
+
+  @Column(name = "valid_to")
+  private LocalDate validTo;
+
+  @Column(name = "created_at", nullable = false)
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
+
+  protected AgencyHotelAuthEntity() {
+  }
+
+  public UUID getId() {
+    return id;
+  }
+}

--- a/src/main/java/com/rubenrzprz/reshub/persistence/AgencyHotelAuthRepository.java
+++ b/src/main/java/com/rubenrzprz/reshub/persistence/AgencyHotelAuthRepository.java
@@ -1,0 +1,25 @@
+package com.rubenrzprz.reshub.persistence;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface AgencyHotelAuthRepository extends JpaRepository<AgencyHotelAuthEntity, UUID> {
+
+  @Query("""
+    select count(a) > 0
+    from AgencyHotelAuthEntity a
+    where a.agencyId = :agencyId
+      and a.hotelId = :hotelId
+      and a.status = 'ACTIVE'
+      and (a.validFrom is null or a.validFrom <= :arrivalDate)
+      and (a.validTo is null or a.validTo >= :arrivalDate)
+    """)
+  boolean existsActiveCoveringDate(
+    @Param("agencyId") UUID agencyId,
+    @Param("hotelId") UUID hotelId,
+    @Param("arrivalDate") LocalDate arrivalDate
+  );
+}

--- a/src/main/java/com/rubenrzprz/reshub/persistence/AgencyRepository.java
+++ b/src/main/java/com/rubenrzprz/reshub/persistence/AgencyRepository.java
@@ -1,0 +1,7 @@
+package com.rubenrzprz.reshub.persistence;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AgencyRepository extends JpaRepository<AgencyEntity, UUID> {
+}

--- a/src/main/java/com/rubenrzprz/reshub/persistence/AppUserEntity.java
+++ b/src/main/java/com/rubenrzprz/reshub/persistence/AppUserEntity.java
@@ -1,0 +1,64 @@
+package com.rubenrzprz.reshub.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "app_user")
+public class AppUserEntity {
+
+  @Id
+  private UUID id;
+
+  @Column(nullable = false, length = 254)
+  private String email;
+
+  @Column(name = "password_hash", nullable = false, length = 72)
+  private String passwordHash;
+
+  @Column(nullable = false, length = 24)
+  private String role;
+
+  @Column(name = "hotel_id")
+  private UUID hotelId;
+
+  @Column(name = "agency_id")
+  private UUID agencyId;
+
+  @Column(name = "created_at", nullable = false)
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
+
+  protected AppUserEntity() {
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getPasswordHash() {
+    return passwordHash;
+  }
+
+  public String getRole() {
+    return role;
+  }
+
+  public UUID getHotelId() {
+    return hotelId;
+  }
+
+  public UUID getAgencyId() {
+    return agencyId;
+  }
+}

--- a/src/main/java/com/rubenrzprz/reshub/persistence/AppUserRepository.java
+++ b/src/main/java/com/rubenrzprz/reshub/persistence/AppUserRepository.java
@@ -1,0 +1,9 @@
+package com.rubenrzprz.reshub.persistence;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AppUserRepository extends JpaRepository<AppUserEntity, UUID> {
+  List<AppUserEntity> findByEmailIgnoreCase(String email);
+}

--- a/src/main/java/com/rubenrzprz/reshub/persistence/HotelEntity.java
+++ b/src/main/java/com/rubenrzprz/reshub/persistence/HotelEntity.java
@@ -1,0 +1,38 @@
+package com.rubenrzprz.reshub.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "hotel")
+public class HotelEntity {
+
+  @Id
+  private UUID id;
+
+  @Column(nullable = false, length = 24)
+  private String code;
+
+  @Column(nullable = false, length = 120)
+  private String name;
+
+  @Column(nullable = false)
+  private boolean active;
+
+  @Column(name = "created_at", nullable = false)
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
+
+  protected HotelEntity() {
+  }
+
+  public UUID getId() {
+    return id;
+  }
+}

--- a/src/main/java/com/rubenrzprz/reshub/persistence/HotelRepository.java
+++ b/src/main/java/com/rubenrzprz/reshub/persistence/HotelRepository.java
@@ -1,0 +1,7 @@
+package com.rubenrzprz.reshub.persistence;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HotelRepository extends JpaRepository<HotelEntity, UUID> {
+}

--- a/src/main/java/com/rubenrzprz/reshub/persistence/ReservationCommentEntity.java
+++ b/src/main/java/com/rubenrzprz/reshub/persistence/ReservationCommentEntity.java
@@ -1,0 +1,65 @@
+package com.rubenrzprz.reshub.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+@Entity
+@Table(name = "reservation_comment")
+public class ReservationCommentEntity {
+
+  @Id
+  private UUID id;
+
+  @Column(name = "reservation_id", nullable = false)
+  private UUID reservationId;
+
+  @Column(name = "author_user_id", nullable = false)
+  private UUID authorUserId;
+
+  @Column(nullable = false, columnDefinition = "text")
+  private String body;
+
+  @Column(name = "created_at", nullable = false)
+  private OffsetDateTime createdAt;
+
+  protected ReservationCommentEntity() {
+  }
+
+  public ReservationCommentEntity(UUID id, UUID reservationId, UUID authorUserId, String body) {
+    this.id = id;
+    this.reservationId = reservationId;
+    this.authorUserId = authorUserId;
+    this.body = body;
+  }
+
+  @PrePersist
+  void prePersist() {
+    createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public UUID getReservationId() {
+    return reservationId;
+  }
+
+  public UUID getAuthorUserId() {
+    return authorUserId;
+  }
+
+  public String getBody() {
+    return body;
+  }
+
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
+  }
+}

--- a/src/main/java/com/rubenrzprz/reshub/persistence/ReservationCommentRepository.java
+++ b/src/main/java/com/rubenrzprz/reshub/persistence/ReservationCommentRepository.java
@@ -1,0 +1,7 @@
+package com.rubenrzprz.reshub.persistence;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationCommentRepository extends JpaRepository<ReservationCommentEntity, UUID> {
+}

--- a/src/main/java/com/rubenrzprz/reshub/persistence/ReservationEntity.java
+++ b/src/main/java/com/rubenrzprz/reshub/persistence/ReservationEntity.java
@@ -1,0 +1,172 @@
+package com.rubenrzprz.reshub.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+@Entity
+@Table(name = "reservation")
+public class ReservationEntity {
+
+  @Id
+  private UUID id;
+
+  @Column(name = "hotel_id", nullable = false)
+  private UUID hotelId;
+
+  @Column(name = "agency_id", nullable = false)
+  private UUID agencyId;
+
+  @Column(name = "created_by_user_id", nullable = false)
+  private UUID createdByUserId;
+
+  @Column(name = "room_type_id")
+  private UUID roomTypeId;
+
+  @Column(name = "external_room_type_code", length = 64)
+  private String externalRoomTypeCode;
+
+  @Column(name = "external_room_type_name", length = 160)
+  private String externalRoomTypeName;
+
+  @Column(name = "external_ref", nullable = false, length = 64)
+  private String externalRef;
+
+  @Column(nullable = false, length = 16)
+  private String status;
+
+  @Column(name = "arrival_date", nullable = false)
+  private LocalDate arrivalDate;
+
+  @Column(name = "departure_date", nullable = false)
+  private LocalDate departureDate;
+
+  @Column(name = "guest_name", nullable = false, length = 160)
+  private String guestName;
+
+  @Column(name = "guest_email", length = 254)
+  private String guestEmail;
+
+  @Column(name = "guest_phone", length = 32)
+  private String guestPhone;
+
+  @Column(nullable = false)
+  private Short adults;
+
+  @Column(nullable = false)
+  private Short children;
+
+  @Column(columnDefinition = "text")
+  private String notes;
+
+  @Column(name = "cancelled_at")
+  private OffsetDateTime cancelledAt;
+
+  @Column(name = "cancel_reason", length = 160)
+  private String cancelReason;
+
+  @Column(name = "created_at", nullable = false)
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
+
+  protected ReservationEntity() {
+  }
+
+  public static ReservationEntity create(
+    UUID id,
+    UUID hotelId,
+    UUID agencyId,
+    UUID createdByUserId,
+    UUID roomTypeId,
+    String externalRoomTypeCode,
+    String externalRoomTypeName,
+    String externalRef,
+    LocalDate arrivalDate,
+    LocalDate departureDate,
+    String guestName,
+    short adults,
+    short children,
+    String notes
+  ) {
+    ReservationEntity entity = new ReservationEntity();
+    entity.id = id;
+    entity.hotelId = hotelId;
+    entity.agencyId = agencyId;
+    entity.createdByUserId = createdByUserId;
+    entity.roomTypeId = roomTypeId;
+    entity.externalRoomTypeCode = externalRoomTypeCode;
+    entity.externalRoomTypeName = externalRoomTypeName;
+    entity.externalRef = externalRef;
+    entity.status = "NEW";
+    entity.arrivalDate = arrivalDate;
+    entity.departureDate = departureDate;
+    entity.guestName = guestName;
+    entity.adults = adults;
+    entity.children = children;
+    entity.notes = notes;
+    return entity;
+  }
+
+  @PrePersist
+  void prePersist() {
+    OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+    createdAt = now;
+    updatedAt = now;
+  }
+
+  @PreUpdate
+  void preUpdate() {
+    updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public UUID getHotelId() {
+    return hotelId;
+  }
+
+  public UUID getAgencyId() {
+    return agencyId;
+  }
+
+  public UUID getCreatedByUserId() {
+    return createdByUserId;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setNotes(String notes) {
+    this.notes = notes;
+  }
+
+  public void confirm() {
+    status = "CONFIRMED";
+    cancelledAt = null;
+    cancelReason = null;
+  }
+
+  public void cancel(String reason) {
+    status = "CANCELLED";
+    cancelledAt = OffsetDateTime.now(ZoneOffset.UTC);
+    cancelReason = reason;
+  }
+
+  public void noShow() {
+    status = "NOSHOW";
+    cancelledAt = null;
+    cancelReason = null;
+  }
+}

--- a/src/main/java/com/rubenrzprz/reshub/persistence/ReservationRepository.java
+++ b/src/main/java/com/rubenrzprz/reshub/persistence/ReservationRepository.java
@@ -1,0 +1,7 @@
+package com.rubenrzprz.reshub.persistence;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationRepository extends JpaRepository<ReservationEntity, UUID> {
+}

--- a/src/main/java/com/rubenrzprz/reshub/reservation/AgencyHotelAuthorizationService.java
+++ b/src/main/java/com/rubenrzprz/reshub/reservation/AgencyHotelAuthorizationService.java
@@ -1,19 +1,22 @@
 package com.rubenrzprz.reshub.reservation;
 
+import com.rubenrzprz.reshub.persistence.AgencyHotelAuthRepository;
 import com.rubenrzprz.reshub.security.RequestActor;
 import java.time.LocalDate;
 import java.util.UUID;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
 public class AgencyHotelAuthorizationService {
 
-  private final JdbcTemplate jdbc;
+  private final AgencyHotelAuthRepository agencyHotelAuthRepository;
   private final ReservationFeatureFlagsProperties flags;
 
-  public AgencyHotelAuthorizationService(JdbcTemplate jdbc, ReservationFeatureFlagsProperties flags) {
-    this.jdbc = jdbc;
+  public AgencyHotelAuthorizationService(
+    AgencyHotelAuthRepository agencyHotelAuthRepository,
+    ReservationFeatureFlagsProperties flags
+  ) {
+    this.agencyHotelAuthRepository = agencyHotelAuthRepository;
     this.flags = flags;
   }
 
@@ -22,22 +25,7 @@ public class AgencyHotelAuthorizationService {
       return true;
     }
 
-    Integer count = jdbc.queryForObject(
-      "select count(*) " +
-        "from agency_hotel_auth " +
-        "where agency_id = ? " +
-        "  and hotel_id = ? " +
-        "  and status = 'ACTIVE' " +
-        "  and (valid_from is null or valid_from <= ?) " +
-        "  and (valid_to is null or valid_to >= ?)",
-      Integer.class,
-      actor.agencyId(),
-      hotelId,
-      date,
-      date
-    );
-
-    return count != null && count > 0;
+    return agencyHotelAuthRepository.existsActiveCoveringDate(actor.agencyId(), hotelId, date);
   }
 
   public boolean isAgencyAuthEnforced(RequestActor actor) {

--- a/src/main/java/com/rubenrzprz/reshub/reservation/ReservationCommandService.java
+++ b/src/main/java/com/rubenrzprz/reshub/reservation/ReservationCommandService.java
@@ -1,12 +1,12 @@
 package com.rubenrzprz.reshub.reservation;
 
 import com.rubenrzprz.reshub.api.ApiProblemException;
+import com.rubenrzprz.reshub.persistence.ReservationCommentEntity;
+import com.rubenrzprz.reshub.persistence.ReservationCommentRepository;
+import com.rubenrzprz.reshub.persistence.ReservationEntity;
+import com.rubenrzprz.reshub.persistence.ReservationRepository;
 import com.rubenrzprz.reshub.security.RequestActor;
-import java.sql.Timestamp;
 import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.util.List;
 import java.util.UUID;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -14,34 +14,40 @@ import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class ReservationCommandService {
 
   private static final Logger log = LoggerFactory.getLogger(ReservationCommandService.class);
 
-  private final JdbcTemplate jdbc;
+  private final ReservationRepository reservationRepository;
+  private final ReservationCommentRepository reservationCommentRepository;
   private final ReservationQueryService reservationQueryService;
   private final AgencyHotelAuthorizationService agencyHotelAuthorizationService;
 
   public ReservationCommandService(
-    JdbcTemplate jdbc,
+    ReservationRepository reservationRepository,
+    ReservationCommentRepository reservationCommentRepository,
     ReservationQueryService reservationQueryService,
     AgencyHotelAuthorizationService agencyHotelAuthorizationService
   ) {
-    this.jdbc = jdbc;
+    this.reservationRepository = reservationRepository;
+    this.reservationCommentRepository = reservationCommentRepository;
     this.reservationQueryService = reservationQueryService;
     this.agencyHotelAuthorizationService = agencyHotelAuthorizationService;
   }
 
+  @Transactional
   public ReservationView updateNotes(UUID reservationId, String notes, RequestActor actor) {
-    ReservationScope scope = loadScope(reservationId, actor);
+    ReservationEntity reservation = loadReservation(reservationId, actor, ReservationRbacLog.EVENT_UPDATE_NOT_FOUND);
+    ReservationScope scope = toScope(reservation);
     enforceMutationAccess(actor, scope, ReservationRbacLog.EVENT_UPDATE_FORBIDDEN);
 
     try {
-      jdbc.update("update reservation set notes = ?, updated_at = now() where id = ?", notes, reservationId);
+      reservation.setNotes(notes);
+      reservationRepository.flush();
     } catch (DataAccessException ex) {
       throw mapMutationViolation(ex);
     }
@@ -60,6 +66,7 @@ public class ReservationCommandService {
     return reservationQueryService.getById(reservationId, actor);
   }
 
+  @Transactional
   public ReservationView createReservation(ReservationCreateRequest request, RequestActor actor) {
     validateCreateRequest(request);
     enforceCreateAccess(actor, request);
@@ -69,11 +76,7 @@ public class ReservationCommandService {
     int children = request.children() == null ? 0 : request.children();
 
     try {
-      jdbc.update(
-        "insert into reservation " +
-          "(id, hotel_id, agency_id, created_by_user_id, room_type_id, external_room_type_code, external_room_type_name, " +
-          "external_ref, status, arrival_date, departure_date, guest_name, adults, children, notes) " +
-          "values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      ReservationEntity reservation = ReservationEntity.create(
         reservationId,
         request.hotelId(),
         request.agencyId(),
@@ -82,14 +85,14 @@ public class ReservationCommandService {
         request.externalRoomTypeCode(),
         request.externalRoomTypeName(),
         request.externalRef(),
-        "NEW",
-        java.sql.Date.valueOf(request.arrivalDate()),
-        java.sql.Date.valueOf(request.departureDate()),
+        request.arrivalDate(),
+        request.departureDate(),
         request.guestName(),
-        adults,
-        children,
+        (short) adults,
+        (short) children,
         request.notes()
       );
+      reservationRepository.saveAndFlush(reservation);
     } catch (DataIntegrityViolationException ex) {
       String message = ex.getMostSpecificCause() == null ? "" : ex.getMostSpecificCause().getMessage();
       if (message.contains("reservation_external_ref_unique")) {
@@ -133,34 +136,37 @@ public class ReservationCommandService {
     return reservationQueryService.getById(reservationId, actor);
   }
 
+  @Transactional
   public ReservationView confirm(UUID reservationId, RequestActor actor) {
     return changeStatus(reservationId, actor, "CONFIRMED", null);
   }
 
+  @Transactional
   public ReservationView cancel(UUID reservationId, String reason, RequestActor actor) {
     return changeStatus(reservationId, actor, "CANCELLED", reason);
   }
 
+  @Transactional
   public ReservationView noShow(UUID reservationId, RequestActor actor) {
     return changeStatus(reservationId, actor, "NOSHOW", null);
   }
 
+  @Transactional
   public ReservationCommentView addComment(UUID reservationId, String body, RequestActor actor) {
     if (body == null || body.isBlank()) {
       throw new ApiProblemException(HttpStatus.BAD_REQUEST, "invalid_comment_payload", "comment body is required");
     }
 
-    ReservationScope scope = loadScope(reservationId, actor, ReservationRbacLog.EVENT_COMMENT_NOT_FOUND);
+    ReservationEntity reservation = loadReservation(reservationId, actor, ReservationRbacLog.EVENT_COMMENT_NOT_FOUND);
+    ReservationScope scope = toScope(reservation);
     enforceCommentAccess(actor, scope);
 
-    UUID commentId = UUID.randomUUID();
-    jdbc.update(
-      "insert into reservation_comment (id, reservation_id, author_user_id, body) values (?, ?, ?, ?)",
-      commentId,
+    ReservationCommentEntity comment = reservationCommentRepository.saveAndFlush(new ReservationCommentEntity(
+      UUID.randomUUID(),
       reservationId,
       actor.userId(),
       body
-    );
+    ));
 
     log.debug(
       "{}",
@@ -174,33 +180,17 @@ public class ReservationCommandService {
     );
     emitAdminWriteAudit(actor, reservationId, "create_comment");
 
-    return jdbc.queryForObject(
-      "select id, reservation_id, author_user_id, body, created_at from reservation_comment where id = ?",
-      (rs, rowNum) -> new ReservationCommentView(
-        UUID.fromString(rs.getString("id")),
-        UUID.fromString(rs.getString("reservation_id")),
-        UUID.fromString(rs.getString("author_user_id")),
-        rs.getString("body"),
-        toOffsetDateTime(rs.getTimestamp("created_at"))
-      ),
-      commentId
+    return new ReservationCommentView(
+      comment.getId(),
+      comment.getReservationId(),
+      comment.getAuthorUserId(),
+      comment.getBody(),
+      comment.getCreatedAt()
     );
   }
 
-  private ReservationScope loadScope(UUID reservationId, RequestActor actor, String notFoundEvent) {
-    List<ReservationScope> rows = jdbc.query(
-      "select id, hotel_id, agency_id, created_by_user_id, status from reservation where id = ?",
-      (rs, rowNum) -> new ReservationScope(
-        UUID.fromString(rs.getString("id")),
-        UUID.fromString(rs.getString("hotel_id")),
-        UUID.fromString(rs.getString("agency_id")),
-        UUID.fromString(rs.getString("created_by_user_id")),
-        rs.getString("status")
-      ),
-      reservationId
-    );
-
-    if (rows.isEmpty()) {
+  private ReservationEntity loadReservation(UUID reservationId, RequestActor actor, String notFoundEvent) {
+    return reservationRepository.findById(reservationId).orElseThrow(() -> {
       log.warn(
         "event={} actorUserId={} actorRole={} actorHotelId={} actorAgencyId={} reservationId={} reason=not_found",
         notFoundEvent,
@@ -210,14 +200,18 @@ public class ReservationCommandService {
         actor.agencyId(),
         reservationId
       );
-      throw new ApiProblemException(HttpStatus.NOT_FOUND, "reservation_not_found", "reservation not found");
-    }
-
-    return rows.getFirst();
+      return new ApiProblemException(HttpStatus.NOT_FOUND, "reservation_not_found", "reservation not found");
+    });
   }
 
-  private ReservationScope loadScope(UUID reservationId, RequestActor actor) {
-    return loadScope(reservationId, actor, ReservationRbacLog.EVENT_UPDATE_NOT_FOUND);
+  private ReservationScope toScope(ReservationEntity reservation) {
+    return new ReservationScope(
+      reservation.getId(),
+      reservation.getHotelId(),
+      reservation.getAgencyId(),
+      reservation.getCreatedByUserId(),
+      reservation.getStatus()
+    );
   }
 
   private void enforceMutationAccess(RequestActor actor, ReservationScope scope, String forbiddenEvent) {
@@ -328,12 +322,9 @@ public class ReservationCommandService {
     throw new ApiProblemException(HttpStatus.FORBIDDEN, "forbidden_scope", "forbidden reservation scope");
   }
 
-  private OffsetDateTime toOffsetDateTime(Timestamp timestamp) {
-    return timestamp == null ? null : timestamp.toInstant().atOffset(ZoneOffset.UTC);
-  }
-
   private ReservationView changeStatus(UUID reservationId, RequestActor actor, String targetStatus, String cancelReason) {
-    ReservationScope scope = loadScope(reservationId, actor, ReservationRbacLog.EVENT_STATUS_NOT_FOUND);
+    ReservationEntity reservation = loadReservation(reservationId, actor, ReservationRbacLog.EVENT_STATUS_NOT_FOUND);
+    ReservationScope scope = toScope(reservation);
     enforceMutationAccess(actor, scope, ReservationRbacLog.EVENT_STATUS_FORBIDDEN);
 
     if (!isAllowedTransition(scope.status(), targetStatus)) {
@@ -356,19 +347,13 @@ public class ReservationCommandService {
 
     try {
       if ("CANCELLED".equals(targetStatus)) {
-        jdbc.update(
-          "update reservation set status = ?, cancelled_at = now(), cancel_reason = ?, updated_at = now() where id = ?",
-          targetStatus,
-          cancelReason,
-          reservationId
-        );
+        reservation.cancel(cancelReason);
+      } else if ("CONFIRMED".equals(targetStatus)) {
+        reservation.confirm();
       } else {
-        jdbc.update(
-          "update reservation set status = ?, cancelled_at = null, cancel_reason = null, updated_at = now() where id = ?",
-          targetStatus,
-          reservationId
-        );
+        reservation.noShow();
       }
+      reservationRepository.flush();
     } catch (DataAccessException ex) {
       throw mapMutationViolation(ex);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: reshub
+  jpa:
+    open-in-view: false
 
 server:
   port: 8080

--- a/src/test/java/com/rubenrzprz/reshub/health/HealthApiIT.java
+++ b/src/test/java/com/rubenrzprz/reshub/health/HealthApiIT.java
@@ -3,14 +3,17 @@ package com.rubenrzprz.reshub.health;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.rubenrzprz.reshub.health.HealthController;
+import com.rubenrzprz.reshub.security.JwtProperties;
 import com.rubenrzprz.reshub.security.JwtService;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -20,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = HealthController.class)
 @AutoConfigureMockMvc(addFilters = false)
+@Import(HealthApiIT.TestJwtConfig.class)
 @TestPropertySource(properties = {
   "spring.application.name=reshub-test"
 })
@@ -31,9 +35,6 @@ class HealthApiIT {
   @Autowired
   MockMvc mvc;
 
-  @MockitoBean
-  JwtService jwtService;
-
   @Test
   void health_returns_ok_with_configured_app_name() throws Exception {
     mvc.perform(get("/health"))
@@ -41,5 +42,13 @@ class HealthApiIT {
       .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
       .andExpect(jsonPath("$.app").value(appName))
       .andExpect(jsonPath("$.status").value("ok"));
+  }
+
+  @TestConfiguration
+  static class TestJwtConfig {
+    @Bean
+    JwtService jwtService() {
+      return new JwtService(new JwtProperties("test-secret-key-with-at-least-32-characters", "reshub-test", 60));
+    }
   }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: reshub-test
+  jpa:
+    open-in-view: false
 
 logging:
   level:


### PR DESCRIPTION
## Summary
Migrate core persistence paths to Spring Data JPA while preserving explicit SQL for query-heavy reservation reads/exports.
- Change: Added schema-mapped JPA entities/repositories and moved auth lookup, agency authorization checks, and reservation command mutations onto repositories.
- Reason: ADR 0001 selected JPA as the interview-friendly default persistence style, with Flyway still owning schema and JdbcTemplate retained only where explicit SQL is clearer.

## Changes
- [added] JPA entities and repositories for core tables:
  - `hotel`, `agency`, `app_user`, `reservation`, `reservation_comment`, `agency_hotel_auth`
- [updated] `AuthService` to use `AppUserRepository`.
- [updated] `AgencyHotelAuthorizationService` to use `AgencyHotelAuthRepository`.
- [updated] `ReservationCommandService` to use repositories for reservation/comment create, notes update, and status transitions.
- [kept] `ReservationQueryService` on `JdbcTemplate` for role-scoped read/list/export/keyset SQL.
- [updated] `spring.jpa.open-in-view=false` in base/test config.
- [updated] health slice test to avoid Mockito bean replacement for `JwtService`.
- [updated] README, Architecture.md, and ADR 0001 with the implemented hybrid persistence boundary.

## How to Test
**Setup**
- Branch: `refactor/core-jpa-persistence`
- Commands:
  - `mvn -q verify` with Java 21
  - local fallback used here: `mvn -q '-Denforcer.skip=true' verify` on Java 25

**Steps**
1) Run the full Maven verification command.
2) Confirm Flyway applies migrations before Hibernate/JPA initializes.
3) Confirm auth token issuance still works.
4) Confirm reservation create/update/status/comment flows still pass.
5) Confirm reservation list/export query behavior remains unchanged.

**Expected**
- JPA repositories initialize successfully against the Flyway-created schema.
- Existing API integration tests remain green.
- `ReservationQueryService` remains the only production `JdbcTemplate` usage.
- `spring.jpa.open-in-view` is disabled.

## Out of Scope
- Rewriting list/export/keyset queries into JPA.
- Changing Flyway migrations or database schema.
- Adding new reservation behavior.
- Full Spring Security migration.

## Risks & Rollback
- Risk: ORM mapping drift could break startup if future migrations and entities diverge; `ddl-auto=validate` in dev/test mitigates this.
- Rollback: `git revert 76f76c1` or revert PR; no data migration impact.

## CI Status
- [ ] CI (build) passes
- [ ] CI (tests) pass
- [ ] Image build/publish (if enabled) passes

## Docs/Meta
- [x] README updated
- [ ] OpenAPI unchanged

## Related
Closes #48
Refs #46