### PR TITLE
refactor: add Bean Validation error handling

### DIFF
--- a/src/main/java/com/rubenrzprz/reshub/api/ApiExceptionHandler.java
+++ b/src/main/java/com/rubenrzprz/reshub/api/ApiExceptionHandler.java
@@ -1,11 +1,16 @@
 package com.rubenrzprz.reshub.api;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ProblemDetail;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.server.ResponseStatusException;
 
 @RestControllerAdvice
@@ -17,6 +22,35 @@ public class ApiExceptionHandler {
     pd.setTitle(titleFor(ex.status()));
     pd.setProperty("code", ex.code());
     pd.setProperty("path", request.getRequestURI());
+    return pd;
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  ProblemDetail handleValidation(MethodArgumentNotValidException ex, HttpServletRequest request) {
+    ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "request validation failed");
+    pd.setTitle("Bad Request");
+    pd.setProperty("code", "validation_failed");
+    pd.setProperty("path", request.getRequestURI());
+    pd.setProperty("errors", validationErrors(ex));
+    return pd;
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  ProblemDetail handleUnreadableMessage(HttpMessageNotReadableException ex, HttpServletRequest request) {
+    ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "malformed request body");
+    pd.setTitle("Bad Request");
+    pd.setProperty("code", "invalid_request_body");
+    pd.setProperty("path", request.getRequestURI());
+    return pd;
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  ProblemDetail handleTypeMismatch(MethodArgumentTypeMismatchException ex, HttpServletRequest request) {
+    ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "invalid request parameter");
+    pd.setTitle("Bad Request");
+    pd.setProperty("code", "invalid_request_parameter");
+    pd.setProperty("path", request.getRequestURI());
+    pd.setProperty("parameter", ex.getName());
     return pd;
   }
 
@@ -79,5 +113,20 @@ public class ApiExceptionHandler {
       return "bad_request";
     }
     return "request_failed";
+  }
+
+  private List<ValidationError> validationErrors(MethodArgumentNotValidException ex) {
+    return ex.getBindingResult()
+      .getFieldErrors()
+      .stream()
+      .map(this::validationError)
+      .toList();
+  }
+
+  private ValidationError validationError(FieldError error) {
+    return new ValidationError(error.getField(), error.getDefaultMessage());
+  }
+
+  private record ValidationError(String field, String message) {
   }
 }

--- a/src/main/java/com/rubenrzprz/reshub/auth/AuthController.java
+++ b/src/main/java/com/rubenrzprz/reshub/auth/AuthController.java
@@ -3,6 +3,7 @@ package com.rubenrzprz.reshub.auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,7 +23,7 @@ public class AuthController {
   @ApiResponse(responseCode = "400", description = "Invalid auth payload")
   @ApiResponse(responseCode = "401", description = "Invalid credentials")
   @PostMapping("/auth/token")
-  public TokenResponse token(@RequestBody TokenRequest request) {
+  public TokenResponse token(@Valid @RequestBody TokenRequest request) {
     return authService.issueToken(request);
   }
 }

--- a/src/main/java/com/rubenrzprz/reshub/auth/TokenRequest.java
+++ b/src/main/java/com/rubenrzprz/reshub/auth/TokenRequest.java
@@ -1,7 +1,16 @@
 package com.rubenrzprz.reshub.auth;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record TokenRequest(
+  @NotBlank
+  @Email
+  @Size(max = 254)
   String email,
+
+  @NotBlank
   String password
 ) {
 }

--- a/src/main/java/com/rubenrzprz/reshub/reservation/ReservationCancelRequest.java
+++ b/src/main/java/com/rubenrzprz/reshub/reservation/ReservationCancelRequest.java
@@ -1,4 +1,9 @@
 package com.rubenrzprz.reshub.reservation;
 
-public record ReservationCancelRequest(String reason) {
+import jakarta.validation.constraints.Size;
+
+public record ReservationCancelRequest(
+  @Size(max = 160)
+  String reason
+) {
 }

--- a/src/main/java/com/rubenrzprz/reshub/reservation/ReservationCommentCreateRequest.java
+++ b/src/main/java/com/rubenrzprz/reshub/reservation/ReservationCommentCreateRequest.java
@@ -1,4 +1,9 @@
 package com.rubenrzprz.reshub.reservation;
 
-public record ReservationCommentCreateRequest(String body) {
+import jakarta.validation.constraints.NotBlank;
+
+public record ReservationCommentCreateRequest(
+  @NotBlank
+  String body
+) {
 }

--- a/src/main/java/com/rubenrzprz/reshub/reservation/ReservationController.java
+++ b/src/main/java/com/rubenrzprz/reshub/reservation/ReservationController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -144,7 +145,7 @@ public class ReservationController {
   @PostMapping("/reservations")
   @ResponseStatus(HttpStatus.CREATED)
   public ReservationView create(
-    @RequestBody ReservationCreateRequest request,
+    @Valid @RequestBody ReservationCreateRequest request,
     @RequestHeader(name = "X-User-Id", required = false) String userId,
     @RequestHeader(name = "X-Role", required = false) String role,
     @RequestHeader(name = "X-Hotel-Id", required = false) String hotelId,
@@ -162,7 +163,7 @@ public class ReservationController {
   @PatchMapping("/reservations/{id}/notes")
   public ReservationView updateNotes(
     @PathVariable UUID id,
-    @RequestBody ReservationNotesUpdateRequest request,
+    @Valid @RequestBody ReservationNotesUpdateRequest request,
     @RequestHeader(name = "X-User-Id", required = false) String userId,
     @RequestHeader(name = "X-Role", required = false) String role,
     @RequestHeader(name = "X-Hotel-Id", required = false) String hotelId,
@@ -182,7 +183,7 @@ public class ReservationController {
   @ResponseStatus(HttpStatus.CREATED)
   public ReservationCommentView addComment(
     @PathVariable UUID id,
-    @RequestBody ReservationCommentCreateRequest request,
+    @Valid @RequestBody ReservationCommentCreateRequest request,
     @RequestHeader(name = "X-User-Id", required = false) String userId,
     @RequestHeader(name = "X-Role", required = false) String role,
     @RequestHeader(name = "X-Hotel-Id", required = false) String hotelId,
@@ -219,7 +220,7 @@ public class ReservationController {
   @PostMapping("/reservations/{id}/cancel")
   public ReservationView cancel(
     @PathVariable UUID id,
-    @RequestBody(required = false) ReservationCancelRequest request,
+    @Valid @RequestBody(required = false) ReservationCancelRequest request,
     @RequestHeader(name = "X-User-Id", required = false) String userId,
     @RequestHeader(name = "X-Role", required = false) String role,
     @RequestHeader(name = "X-Hotel-Id", required = false) String hotelId,

--- a/src/main/java/com/rubenrzprz/reshub/reservation/ReservationCreateRequest.java
+++ b/src/main/java/com/rubenrzprz/reshub/reservation/ReservationCreateRequest.java
@@ -1,20 +1,47 @@
 package com.rubenrzprz.reshub.reservation;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.util.UUID;
 
 public record ReservationCreateRequest(
+  @NotNull
   UUID hotelId,
+
+  @NotNull
   UUID agencyId,
+
   UUID roomTypeId,
+
+  @Size(max = 64)
   String externalRoomTypeCode,
+
+  @Size(max = 160)
   String externalRoomTypeName,
+
+  @NotBlank
+  @Size(max = 64)
   String externalRef,
+
+  @NotNull
   LocalDate arrivalDate,
+
+  @NotNull
   LocalDate departureDate,
+
+  @NotBlank
+  @Size(max = 160)
   String guestName,
+
+  @Min(1)
   Integer adults,
+
+  @Min(0)
   Integer children,
+
   String notes
 ) {
 }

--- a/src/test/java/com/rubenrzprz/reshub/auth/AuthApiIT.java
+++ b/src/test/java/com/rubenrzprz/reshub/auth/AuthApiIT.java
@@ -42,6 +42,29 @@ class AuthApiIT extends AuthApiIntegrationTestBase {
   }
 
   @Test
+  void invalidAuthPayloadReturnsValidationProblem() {
+    client.post().uri("/auth/token")
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(Map.of("email", "not-an-email", "password", VALID_PASSWORD))
+      .exchange()
+      .expectStatus().isBadRequest()
+      .expectBody()
+      .jsonPath("$.code").isEqualTo("validation_failed")
+      .jsonPath("$.errors[0].field").isEqualTo("email");
+  }
+
+  @Test
+  void malformedAuthJsonReturnsInvalidRequestBody() {
+    client.post().uri("/auth/token")
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue("{")
+      .exchange()
+      .expectStatus().isBadRequest()
+      .expectBody()
+      .jsonPath("$.code").isEqualTo("invalid_request_body");
+  }
+
+  @Test
   void missingBearerOnReservationsReturnsUnauthorized() {
     client.get().uri("/reservations")
       .exchange()

--- a/src/test/java/com/rubenrzprz/reshub/reservation/ReservationReadApiIT.java
+++ b/src/test/java/com/rubenrzprz/reshub/reservation/ReservationReadApiIT.java
@@ -381,4 +381,18 @@ public class ReservationReadApiIT extends ReservationApiIntegrationTestBase {
       .expectBody()
       .jsonPath("$.code").isEqualTo("invalid_date_range");
   }
+
+  @Test
+  void invalidDateQueryParameterIsBadRequest() {
+    client.get().uri(uriBuilder -> uriBuilder.path("/reservations")
+        .queryParam("arrivalFrom", "not-a-date")
+        .queryParam("limit", 50)
+        .build())
+      .header("Authorization", "Bearer " + managerToken)
+      .exchange()
+      .expectStatus().isBadRequest()
+      .expectBody()
+      .jsonPath("$.code").isEqualTo("invalid_request_parameter")
+      .jsonPath("$.parameter").isEqualTo("arrivalFrom");
+  }
 }

--- a/src/test/java/com/rubenrzprz/reshub/reservation/ReservationWriteStatusApiIT.java
+++ b/src/test/java/com/rubenrzprz/reshub/reservation/ReservationWriteStatusApiIT.java
@@ -307,6 +307,28 @@ public class ReservationWriteStatusApiIT extends ReservationApiIntegrationTestBa
   }
 
   @Test
+  void invalidCreateFieldReturnsValidationProblem() {
+    client.post().uri("/reservations")
+      .header("Authorization", "Bearer " + managerToken)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(Map.of(
+        "hotelId", seed.hotelId().toString(),
+        "agencyId", seed.agencyId().toString(),
+        "externalRef", "ext-create-invalid-field",
+        "arrivalDate", "2026-02-25",
+        "departureDate", "2026-02-26",
+        "guestName", "Bad Field Guest",
+        "adults", 0,
+        "children", 0
+      ))
+      .exchange()
+      .expectStatus().isBadRequest()
+      .expectBody()
+      .jsonPath("$.code").isEqualTo("validation_failed")
+      .jsonPath("$.errors[0].field").isEqualTo("adults");
+  }
+
+  @Test
   void cancelledReservationCannotBeUpdated() {
     client.post().uri("/reservations/{id}/cancel", reservationId)
       .header("Authorization", "Bearer " + managerToken)


### PR DESCRIPTION
## Summary
Add Bean Validation at the API boundary and centralize common bad-request error handling.
- Change: Added validation annotations, `@Valid` request bodies, ProblemDetail handlers for validation/body/parameter errors, and API tests for those paths.
- Reason: Controllers should reject malformed or invalid input consistently before service/business logic runs, while preserving domain-specific service errors for cross-field rules.

## Changes
- [updated] `TokenRequest` with email/password validation constraints.
- [updated] reservation request DTOs with required, size, and numeric constraints.
- [updated] auth/reservation controllers to use `@Valid` on request bodies.
- [updated] `ApiExceptionHandler` for:
  - `MethodArgumentNotValidException` -> `validation_failed`
  - `HttpMessageNotReadableException` -> `invalid_request_body`
  - `MethodArgumentTypeMismatchException` -> `invalid_request_parameter`
- [added] integration coverage for invalid auth payloads, malformed JSON, invalid reservation fields, and invalid date query parameters.

## How to Test
**Setup**
- Branch: `refactor/bean-validation-errors`
- Commands:
  - `mvn -q verify` with Java 21
  - local fallback used here: `mvn -q '-Denforcer.skip=true' verify` on Java 25

**Steps**
1) Run the full Maven verification command.
2) POST `/auth/token` with an invalid email.
3) POST `/auth/token` with malformed JSON.
4) POST `/reservations` with `adults=0` and a valid bearer token.
5) GET `/reservations?arrivalFrom=not-a-date` with a valid bearer token.

**Expected**
- Invalid field values return `400` with `code=validation_failed` and field errors.
- Malformed JSON returns `400` with `code=invalid_request_body`.
- Invalid query parameter conversion returns `400` with `code=invalid_request_parameter`.
- Existing domain errors, such as `invalid_reservation_payload` for cross-field reservation rules, remain covered.

## Out of Scope
- Replacing all service-level business validation.
- Full OpenAPI schema/example polish.
- Security/RBAC changes.

## Risks & Rollback
- Risk: Clients may see more precise `400` codes for API-boundary validation failures than before.
- Rollback: `git revert eb70000` or revert PR; no data migration impact.

## CI Status
- [ ] CI (build) passes
- [ ] CI (tests) pass
- [ ] Image build/publish (if enabled) passes

## Docs/Meta
- [ ] README unchanged
- [ ] OpenAPI unchanged

## Related
Closes #51