### PR TITLE
feat: add dev demo seed flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ docker compose up --build
 #### 📌 Notes
 
 * On startup, **Flyway automatically applies database migrations**.
-* The API runs with the `dev` profile when started via Docker Compose.
+* The API runs with the `dev` profile when started via Docker Compose, including demo seed data.
 * If port `8080` is busy, set `APP_PORT=8081` in `.env` and re-run.
 * `JWT_SECRET` is required; startup fails if missing/weak.
 * Stop with `Ctrl + C` (foreground) or `docker compose down`.
@@ -140,12 +140,21 @@ for the target hotel whose validity window includes the reservation `arrival_dat
 
 ### 🔐 Authentication (JWT)
 
+Docker Compose runs the API with the `dev` profile and seeds these demo users:
+
+| Role | Email | Password |
+|------|-------|----------|
+| ADMIN | `admin@reshub.local` | `secret123` |
+| MANAGER | `manager@reshub.local` | `secret123` |
+| RECEPTIONIST | `reception@reshub.local` | `secret123` |
+| AGENCY | `agency@reshub.local` | `secret123` |
+
 1. Request a token:
 
 ```bash
 curl -X POST http://localhost:8080/auth/token \
   -H "Content-Type: application/json" \
-  -d '{"email":"<user-email>","password":"<user-password>"}'
+  -d '{"email":"manager@reshub.local","password":"secret123"}'
 ```
 
 2. Use the `accessToken` value as bearer token:
@@ -159,6 +168,7 @@ curl http://localhost:8080/reservations \
 
 * Reservation endpoints use bearer authentication.
 * Legacy actor headers (`X-User-Id`, `X-Role`, `X-Hotel-Id`, `X-Agency-Id`) are disabled.
+* Demo users are loaded only by the `dev` Flyway location (`classpath:db/dev`), not by test or production profiles.
 * If agency-hotel auth is enabled and denied, API returns `403` with code `agency_not_authorized_for_hotel`.
 
 ### 📤 Export Endpoints

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,4 +13,4 @@ spring:
     open-in-view: false
   flyway:
     enabled: true
-    locations: classpath:db/migration
+    locations: classpath:db/migration,classpath:db/dev

--- a/src/main/resources/db/dev/R__dev_seed_data.sql
+++ b/src/main/resources/db/dev/R__dev_seed_data.sql
@@ -1,0 +1,146 @@
+-- Development-only demo data. Loaded only when the dev profile includes classpath:db/dev.
+insert into hotel (id, code, name, active)
+values ('10000000-0000-0000-0000-000000000001', 'DEMO-HOTEL', 'ResHub Demo Hotel', true)
+on conflict (code) do update
+set name = excluded.name,
+    active = excluded.active,
+    updated_at = now();
+
+insert into agency (id, code, name, active)
+values ('20000000-0000-0000-0000-000000000001', 'DEMO-AGENCY', 'ResHub Demo Agency', true)
+on conflict (code) do update
+set name = excluded.name,
+    active = excluded.active,
+    updated_at = now();
+
+insert into room_type (
+  id,
+  hotel_id,
+  code,
+  name,
+  class,
+  base_occupancy,
+  max_occupancy,
+  attributes_raw,
+  attributes_canonical,
+  flexible_bedding
+)
+values (
+  '30000000-0000-0000-0000-000000000001',
+  '10000000-0000-0000-0000-000000000001',
+  'DLX',
+  'Deluxe Double',
+  'DELUXE',
+  2,
+  3,
+  '{"beds":"1 queen or 2 twin","view":"city"}'::jsonb,
+  '{"beds":["queen","twin"],"view":"city"}'::jsonb,
+  true
+)
+on conflict (hotel_id, code) do update
+set name = excluded.name,
+    class = excluded.class,
+    base_occupancy = excluded.base_occupancy,
+    max_occupancy = excluded.max_occupancy,
+    attributes_raw = excluded.attributes_raw,
+    attributes_canonical = excluded.attributes_canonical,
+    flexible_bedding = excluded.flexible_bedding,
+    updated_at = now();
+
+insert into app_user (id, email, password_hash, role, hotel_id, agency_id)
+values
+  (
+    '40000000-0000-0000-0000-000000000001',
+    'admin@reshub.local',
+    '$2a$10$U6O3LOtTgPbTRkWWZ70Kt.nn9sZ5QPmJcX.dVgzv1m8TwYz5aZ6ci',
+    'ADMIN',
+    '10000000-0000-0000-0000-000000000001',
+    null
+  ),
+  (
+    '40000000-0000-0000-0000-000000000002',
+    'manager@reshub.local',
+    '$2a$10$U6O3LOtTgPbTRkWWZ70Kt.nn9sZ5QPmJcX.dVgzv1m8TwYz5aZ6ci',
+    'MANAGER',
+    '10000000-0000-0000-0000-000000000001',
+    null
+  ),
+  (
+    '40000000-0000-0000-0000-000000000003',
+    'reception@reshub.local',
+    '$2a$10$U6O3LOtTgPbTRkWWZ70Kt.nn9sZ5QPmJcX.dVgzv1m8TwYz5aZ6ci',
+    'RECEPTIONIST',
+    '10000000-0000-0000-0000-000000000001',
+    null
+  ),
+  (
+    '40000000-0000-0000-0000-000000000004',
+    'agency@reshub.local',
+    '$2a$10$U6O3LOtTgPbTRkWWZ70Kt.nn9sZ5QPmJcX.dVgzv1m8TwYz5aZ6ci',
+    'AGENCY',
+    null,
+    '20000000-0000-0000-0000-000000000001'
+  )
+on conflict (email) do update
+set password_hash = excluded.password_hash,
+    role = excluded.role,
+    hotel_id = excluded.hotel_id,
+    agency_id = excluded.agency_id,
+    updated_at = now();
+
+insert into agency_hotel_auth (id, agency_id, hotel_id, status, valid_from, valid_to, terms_json)
+values (
+  '50000000-0000-0000-0000-000000000001',
+  '20000000-0000-0000-0000-000000000001',
+  '10000000-0000-0000-0000-000000000001',
+  'ACTIVE',
+  current_date - 30,
+  null,
+  '{"source":"dev-seed"}'::jsonb
+)
+on conflict (agency_id, hotel_id) do update
+set status = excluded.status,
+    valid_from = excluded.valid_from,
+    valid_to = excluded.valid_to,
+    terms_json = excluded.terms_json,
+    updated_at = now();
+
+insert into reservation (
+  id,
+  hotel_id,
+  agency_id,
+  created_by_user_id,
+  room_type_id,
+  external_room_type_code,
+  external_room_type_name,
+  external_ref,
+  status,
+  arrival_date,
+  departure_date,
+  guest_name,
+  guest_email,
+  guest_phone,
+  adults,
+  children,
+  notes
+)
+values (
+  '60000000-0000-0000-0000-000000000001',
+  '10000000-0000-0000-0000-000000000001',
+  '20000000-0000-0000-0000-000000000001',
+  '40000000-0000-0000-0000-000000000004',
+  '30000000-0000-0000-0000-000000000001',
+  'DLX',
+  'Deluxe Double',
+  'DEMO-RES-001',
+  'NEW',
+  current_date + 14,
+  current_date + 17,
+  'Alex Demo',
+  'alex.demo@example.com',
+  '+34928000000',
+  2,
+  0,
+  'Seeded reservation for local API demos.'
+)
+on conflict (hotel_id, agency_id, external_ref) do nothing;

--- a/src/test/java/com/rubenrzprz/reshub/flyway/FlywayDevSeedIT.java
+++ b/src/test/java/com/rubenrzprz/reshub/flyway/FlywayDevSeedIT.java
@@ -1,0 +1,81 @@
+package com.rubenrzprz.reshub.flyway;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.flywaydb.core.Flyway;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+class FlywayDevSeedIT {
+
+  @SuppressWarnings("resource")
+  private static final PostgreSQLContainer<?> postgres =
+    new PostgreSQLContainer<>("postgres:16-alpine")
+      .withDatabaseName("reshub-dev-seed")
+      .withUsername("reshub")
+      .withPassword("reshub");
+
+  static {
+    postgres.start();
+  }
+
+  @AfterAll
+  static void stopPostgres() {
+    postgres.stop();
+  }
+
+  @Test
+  void devSeedCreatesDemoLoginPath() throws SQLException {
+    Flyway.configure()
+      .dataSource(postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword())
+      .locations("classpath:db/migration", "classpath:db/dev")
+      .load()
+      .migrate();
+
+    try (Connection connection = DriverManager.getConnection(
+      postgres.getJdbcUrl(),
+      postgres.getUsername(),
+      postgres.getPassword()
+    )) {
+      int userCount = count(
+        connection,
+        "select count(*) from app_user where email in (?, ?, ?, ?)",
+        "admin@reshub.local",
+        "manager@reshub.local",
+        "reception@reshub.local",
+        "agency@reshub.local"
+      );
+      int reservationCount = count(
+        connection,
+        "select count(*) from reservation where external_ref = ?",
+        "DEMO-RES-001"
+      );
+      int authCount = count(
+        connection,
+        "select count(*) from agency_hotel_auth where status = 'ACTIVE'"
+      );
+
+      Assertions.assertEquals(4, userCount);
+      Assertions.assertEquals(1, reservationCount);
+      Assertions.assertTrue(authCount >= 1);
+    }
+  }
+
+  private static int count(Connection connection, String sql, String... values)
+    throws SQLException {
+    try (PreparedStatement statement = connection.prepareStatement(sql)) {
+      for (int i = 0; i < values.length; i++) {
+        statement.setString(i + 1, values[i]);
+      }
+      try (ResultSet resultSet = statement.executeQuery()) {
+        Assertions.assertTrue(resultSet.next());
+        return resultSet.getInt(1);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
One sentence: add dev-only seed data so reviewers can authenticate and explore the API from a clean Docker Compose stack.
- Change: add a dev Flyway seed location, deterministic demo users/domain data, and README login commands.
- Reason: the current README described JWT flow but did not provide credentials for a fresh local database.

## Changes
- added `classpath:db/dev` to the `dev` Flyway locations.
- added repeatable dev seed data for a demo hotel, agency, users, authorization row, room type, and reservation.
- added an isolated Flyway/Testcontainers integration test for the dev seed migration.
- updated README authentication docs with demo users and copy-pasteable token command.

## How to Test
**Setup**
- Branch: `feat/dev-seed-demo-flow`
- Commands: `mvn -q '-Denforcer.skip=true' verify`

**Steps**
1) Run the verification command above.
2) Start the app with Docker Compose using the default `dev` profile.
3) Request a token with `manager@reshub.local` / `secret123` and call `/reservations` with the bearer token.

**Expected**
- Maven verification passes.
- Dev Flyway migration applies from `classpath:db/dev` only for the dev profile.
- Demo credentials authenticate successfully on a fresh dev database.

## Out of Scope
- Production seed data.
- New reservation features or role changes.
- Full Spring Security migration.

## Risks & Rollback
- Risk: demo credentials exist in local dev profile; they are isolated from test and production Flyway locations.
- Rollback: `git revert <sha>` or revert PR; no data migration impact (yes, dev-only repeatable seed migration).

## CI Status
- [x] CI (build) passes
- [x] CI (tests) pass
- [ ] Image build/publish (if enabled) passes

## Docs/Meta
- [x] README touched? `README.md`
- [ ] OpenAPI visible/updated? (path/link)

Closes #53