### PR TITLE
docs: add core architecture decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ See the full domain & data model in **[📐 Architecture](docs/Architecture.md)*
 ## 📐 Architecture
 
 High-level overview of the domain & data model. For the full spec, see **[docs/Architecture.md](docs/Architecture.md)**.
+Technical decision records live in **[docs/decisions](docs/decisions)**.
 
 - **Tenancy:** single DB; entities scoped by `hotel_id` where applicable.
 - **Persistence:** Spring Data JPA for core aggregate commands/lookups; explicit `JdbcTemplate` SQL for role-scoped list/export queries.

--- a/docs/decisions/0003-use-flyway-for-schema-management.md
+++ b/docs/decisions/0003-use-flyway-for-schema-management.md
@@ -1,0 +1,26 @@
+# 0003 - Use Flyway for schema management
+
+## Context
+
+ResHub uses PostgreSQL and needs a repeatable way to create and evolve schema across local development, CI, and Testcontainers integration tests.
+Relying on Hibernate DDL generation would make schema ownership less explicit and harder to review.
+
+## Decision
+
+Use Flyway versioned migrations as the source of truth for database schema.
+Hibernate runs with `ddl-auto=validate` so JPA mappings are checked against the Flyway-managed schema instead of generating tables.
+
+## Rationale
+
+Flyway keeps database changes reviewable, ordered, and reproducible.
+It also lets the project demonstrate SQL constraints, indexes, triggers, and PostgreSQL-specific features directly.
+
+## Trade-offs
+
+- Schema changes require explicit migration files.
+- JPA entity changes can fail startup until the matching migration exists.
+- Developers must understand both JPA mappings and SQL migrations.
+
+## Future Evolution
+
+For larger teams, migrations could include rollback guidance and stricter review rules for destructive changes.

--- a/docs/decisions/0004-use-postgresql-and-testcontainers.md
+++ b/docs/decisions/0004-use-postgresql-and-testcontainers.md
@@ -1,0 +1,26 @@
+# 0004 - Use PostgreSQL and Testcontainers
+
+## Context
+
+Reservation behavior depends on database constraints, date filtering, JSONB room attributes, and migration correctness.
+An in-memory database would not reliably match PostgreSQL behavior.
+
+## Decision
+
+Use PostgreSQL as the development, CI, and test database.
+Use Testcontainers for integration tests that need a real PostgreSQL instance.
+
+## Rationale
+
+Testing against PostgreSQL catches migration, SQL, constraint, and dialect issues before merge.
+It keeps local and CI behavior close to production assumptions without requiring developers to manage a long-lived local test database.
+
+## Trade-offs
+
+- Integration tests require Docker.
+- Test startup is slower than in-memory database tests.
+- CI depends on container support.
+
+## Future Evolution
+
+If the test suite grows, tests can be split into faster unit slices and slower database/API suites while keeping PostgreSQL for persistence verification.

--- a/docs/decisions/0005-use-problemdetail-error-contract.md
+++ b/docs/decisions/0005-use-problemdetail-error-contract.md
@@ -1,0 +1,26 @@
+# 0005 - Use ProblemDetail error responses
+
+## Context
+
+Clients need predictable API errors for validation failures, authentication failures, forbidden scope, not found, conflicts, and malformed requests.
+Scattering error response construction across controllers would make the contract inconsistent.
+
+## Decision
+
+Use Spring `ProblemDetail` as the standard error shape and centralize mapping in the global exception handler.
+Each application error includes a stable `code` property that tests and clients can rely on.
+
+## Rationale
+
+`ProblemDetail` is the Spring Boot 3-native representation for RFC 9457-style API errors.
+Stable error codes are easier to assert in tests and easier for clients to handle than parsing human-readable messages.
+
+## Trade-offs
+
+- Error codes must be maintained as part of the API contract.
+- Some low-level exceptions need explicit mapping to avoid leaking implementation details.
+- The project still keeps the contract intentionally compact rather than modeling every possible error subtype.
+
+## Future Evolution
+
+OpenAPI examples can be expanded so Swagger shows the common error bodies for each endpoint.

--- a/docs/decisions/0006-use-reservation-lifecycle-command-endpoints.md
+++ b/docs/decisions/0006-use-reservation-lifecycle-command-endpoints.md
@@ -1,0 +1,26 @@
+# 0006 - Use reservation lifecycle command endpoints
+
+## Context
+
+Reservations have a small lifecycle: `NEW`, `CONFIRMED`, `CANCELLED`, and `NOSHOW`.
+Status changes are business actions, not generic partial updates.
+
+## Decision
+
+Expose lifecycle transitions as command endpoints such as `/reservations/{id}/confirm`, `/cancel`, and `/noshow`.
+Keep validation and authorization in the service layer, with database guardrails preventing invalid terminal-state mutations.
+
+## Rationale
+
+Command endpoints make allowed business actions explicit and easier to demo.
+They also avoid ambiguous generic status updates where clients could attempt unsupported transitions.
+
+## Trade-offs
+
+- The API has more endpoints than a generic `PATCH /reservations/{id}` status field.
+- Adding new transitions requires adding or documenting a new command.
+- Some teams may prefer a generic state transition endpoint for larger workflows.
+
+## Future Evolution
+
+If the workflow grows, transitions could move behind a dedicated state-machine component while keeping the public command style.

--- a/docs/decisions/0007-keep-layered-monolith-boundary.md
+++ b/docs/decisions/0007-keep-layered-monolith-boundary.md
@@ -1,0 +1,26 @@
+# 0007 - Keep a layered monolith boundary
+
+## Context
+
+ResHub is a backend portfolio project for a single hotel reservation domain.
+The project needs to show serious backend design without adding distributed-system complexity that the problem does not require.
+
+## Decision
+
+Keep the application as a layered Spring Boot monolith with clear API, service, persistence, migration, and test boundaries.
+Do not split into microservices for the current scope.
+
+## Rationale
+
+A monolith is easier to run, test, review, and explain for this domain.
+It keeps the focus on correctness, data modeling, transactions, validation, security, and API design instead of infrastructure.
+
+## Trade-offs
+
+- Module boundaries are enforced by package structure and discipline rather than deployment boundaries.
+- Independent scaling is not available per domain area.
+- Future teams would need to watch for service-layer coupling as features grow.
+
+## Future Evolution
+
+If the domain expanded substantially, bounded contexts could first be separated into modules before considering service extraction.


### PR DESCRIPTION
## Summary
One sentence: add core ADRs so the backend architecture choices are easy to explain in interviews.
- Change: add decision records for Flyway, PostgreSQL/Testcontainers, ProblemDetail, reservation lifecycle commands, and layered monolith boundaries.
- Reason: after the JPA and Spring Security decisions, the remaining core backend choices needed concise written rationale.

## Changes
- added `0003-use-flyway-for-schema-management.md`.
- added `0004-use-postgresql-and-testcontainers.md`.
- added `0005-use-problemdetail-error-contract.md`.
- added `0006-use-reservation-lifecycle-command-endpoints.md`.
- added `0007-keep-layered-monolith-boundary.md`.
- linked `docs/decisions` from the README architecture section.

## How to Test
**Setup**
- Branch: `docs/core-architecture-decisions`
- Commands: not run locally; docs-only change.

**Steps**
1) Review `docs/decisions`.
2) Confirm numbering is contiguous from `0001` through `0007`.
3) Confirm each ADR has Context, Decision, Rationale, Trade-offs, and Future Evolution sections.

**Expected**
- ADR numbering is contiguous.
- Each core backend choice has a concise, interview-defendable rationale.
- README links reviewers to `docs/decisions`.

## Out of Scope
- Runtime behavior changes.
- API contract changes.
- New features.

## Risks & Rollback
- Risk: low; documentation-only change.
- Rollback: `git revert <sha>` or revert PR; no data migration impact (yes, docs-only).

## CI Status
- [ ] CI (build) passes - N/A, workflow is skipped for docs-only changes
- [ ] CI (tests) pass - N/A, workflow is skipped for docs-only changes
- [ ] Image build/publish (if enabled) passes

## Docs/Meta
- [x] README touched? `README.md`
- [ ] OpenAPI visible/updated? (path/link)

Closes #57